### PR TITLE
Incoming page is now Symbols page under Crashes/Diagnostics service.

### DIFF
--- a/docs/crashes/ios.md
+++ b/docs/crashes/ios.md
@@ -23,7 +23,7 @@ ms.tgt_pltfrm: ios
 ## Getting Started
 
 1. Integrate the SDK as described in the [Getting Started with iOS](~/sdk/getting-started/ios.md) documentation.
-2. Upload the symbols that are created with each build using the *Incoming* page under the app.
+2. Upload the symbols that are created with each build using the **Symbols** page under the app.
 3. Add a test crash to the app's code by calling the `generateTestCrash` method of the crash reporting module as an action to a button.
 4. Run the app without the debugger connected, crash it and restart it.
 5. After a few minutes the crash report should be visible in the UI.
@@ -31,7 +31,7 @@ ms.tgt_pltfrm: ios
 ## Uploading symbols
 
 1. Create a ZIP file for the dSYM package on your Mac.
-2. Open the *Incoming* page under *Crash Reporting* on App Center of the app.
+2. Open the **Symbols** page under **Crashes** service on App Center of the app.
 3. Upload the zip file.
 4. After the zip file is indexed by App Center new incoming crashes will be symbolicated.
 

--- a/docs/crashes/macos.md
+++ b/docs/crashes/macos.md
@@ -23,7 +23,7 @@ ms.tgt_pltfrm: macos
 ## Getting Started
 
 1. Integrate the SDK as described in the [Getting Started with macOS](~/sdk/getting-started/macos.md) documentation.
-2. Upload the symbols that are created with each build using the *Incoming* page under the app.
+2. Upload the symbols that are created with each build using the **Symbols** page under the app.
 3. Add a test crash to the app's code by calling the `generateTestCrash` method of the crash reporting module as an action to a button.
 4. Run the app without the debugger connected, crash it and restart it.
 5. After a few minutes the crash report should be visible in the UI.
@@ -31,7 +31,7 @@ ms.tgt_pltfrm: macos
 ## Uploading symbols
 
 1. Create a ZIP file for the dSYM package on your Mac.
-2. Open the *Incoming* page under *Crash Reporting* on App Center of the app.
+2. Open the **Symbols** page under **Crashes** service on App Center of the app.
 3. Upload the zip file.
 4. After the zip file is indexed by App Center new incoming crashes will be symbolicated.
 

--- a/docs/crashes/react-native.md
+++ b/docs/crashes/react-native.md
@@ -23,7 +23,7 @@ ms.tgt_pltfrm: react-native
 ## Getting Started
 
 1. Integrate the SDK as described in the [Getting Started with React Native](~/sdk/getting-started/react-native.md) documentation.
-2. Upload the symbols that are created with each build using the *Incoming* page under the app.
+2. Upload the symbols that are created with each build using the **Symbols** page under the app.
 3. Add a test crash to the app's code by calling the `generateTestCrash` method of the crash reporting module as an action to a button.
 4. Run the app without the debugger connected, crash it and restart it.
 5. After a few minutes the crash report should be visible in the UI.
@@ -38,7 +38,7 @@ ms.tgt_pltfrm: react-native
 
     > The App Center Build service automatically generates a valid dSYM and source map .zip file, and uploads it to the Crashes service, meaning you can skip all these steps.
 
-2. Open the *Incoming* page under *Crash Reporting* on App Center of the app.
+2. Open the **Symbols** page under **Crashes** service on App Center of the app.
 3. Upload the zip file.
 4. After the zip file is indexed by App Center new incoming crashes will be symbolicated.
 


### PR DESCRIPTION
[Quickstart guide](https://docs.microsoft.com/en-us/appcenter/quickstarts/ios/crashes#upload-symbols) describes the process of uploading symbols correctly.

However `Crashes`->`iOS/React Native/macOS` guides refer to non-existent pages.
As been noticed here https://github.com/Microsoft/appcenter-cli/issues/181#issuecomment-346591758. @amchew 