### PR TITLE
Add matchinFallbacks to Android tutorial

### DIFF
--- a/docs/distribution/codepush/react-native.md
+++ b/docs/distribution/codepush/react-native.md
@@ -703,6 +703,10 @@ To set this up, perform the following steps:
             releaseStaging {
                 ...
                 buildConfigField "String", "CODEPUSH_KEY", '"<INSERT_STAGING_KEY>"'
+                
+                // Note: It is a good idea to provide matchingFallbacks for the new buildType you create to prevent build issues
+                // Add the following line if not already there
+                matchingFallbacks = ['release']
                 ...
             }
 


### PR DESCRIPTION
This commit improves the documentation on multi-delpoyment testing for Android by adding `matchinFallbacks` to `releaseStaging` definition sample. Without providing a fallback to a known build variant, Gradle is unable to resolve libraries since it will try to resolve the dependencies in `releaseStaging` class path which almost no library supports.