### PR TITLE
Update compatibility table for react-native-code-push plugin

### DIFF
--- a/docs/distribution/codepush/react-native.md
+++ b/docs/distribution/codepush/react-native.md
@@ -50,7 +50,8 @@ We try our best to maintain backwards compatability of our plugin with previous 
 | v0.46                   | v4.0+ *(RN refactored js bundle loader code)*         |
 | v0.46-v0.53             | v5.1+ *(RN removed unused registration of JS modules)*|
 | v0.54-v0.55             | v5.3+ *(Android Gradle Plugin 3.x integration)*       |
-| v0.55+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
+| v0.56                   | v5.4+ *(RN upgraded versions for Android tools)*      |
+| v0.56+                  | TBD :) We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.
 
 ### Supported Components
 


### PR DESCRIPTION
Keeping sync with compatibility table https://github.com/Microsoft/react-native-code-push#supported-react-native-platforms

Related PR: https://github.com/Microsoft/react-native-code-push/pull/1344