### PR TITLE
XCUITest: make the AppCenterXCUITestExtension.framework deprecation notice stronger

### DIFF
--- a/docs/test-cloud/preparing-for-upload/xcuitest-extension.md
+++ b/docs/test-cloud/preparing-for-upload/xcuitest-extension.md
@@ -11,21 +11,34 @@ ms.service: vs-appcenter
 ms.custom: test
 ---
 
+## App Center XCUITest Extensions framework
+
+This framework has been _deprecated_.
+
+This framework is _no longer required_ for running XCUITest tests in App
+Center.
+
+This framework will not be updated to be compatible versions of Xcode > 10.0.
+
+Users need to migrate their tests to use Apple's
+`XCTContext runActivityNamed:block` API.
+
+If you are just starting with XCUITest, do not link this framework.
+
 ## Preparing XCUITest Tests for Upload with Extensions
 
-**This framework is *no longer required* for running XCUITest in App Center.**
+If you are already running XCUITest in App Center using the
+AppCenterXCUITestExtensions.framework, you need to migrate your tests to
+use Apple's `XCTContext runActivityNamed:block` API.
 
-Running XCUITest in App Center Test no longer requires the proprietary extensions described here. If you are just starting out with XCUITest in App Center do not use this approach. If you are already running XCUITest in App Center with these extensions consider migrating to the extension-less approach.
 
-For additional information, see the [App Center XCUITest documentation](~/test-cloud/preparing-for-upload/xcuitest.md).
+For additional information and examples, see the [App Center XCUITest documentation](~/test-cloud/preparing-for-upload/xcuitest.md).
 
 The steps necessary to prepare an app and its corresponding test suite for upload to App Center vary depending on the test framework. The section below provides instructions for preparing XCUITest tests for upload to App Center Test.
 
 [AppCenter XCUITest Extensions](https://github.com/Microsoft/AppCenter-Test-XCUITest-Extensions) is an iOS Framework for taking screenshots and labeling test steps when running XCUITest test in App Center. At the conclusion of each test method, a label and screenshot are automatically generated for the test report. You can create additional labels and screenshots to track your app's progress during a test method.
 
 **This framework is *no longer required* for running XCUITest in App Center.** See the note at the top of this page.
-
-If you encounter a problem, please file a [Github issue](https://github.com/Microsoft/AppCenter-Test-XCUITest-Extensions/issues).
 
 ## Requirements
 

--- a/docs/test-cloud/preparing-for-upload/xcuitest-extension.md
+++ b/docs/test-cloud/preparing-for-upload/xcuitest-extension.md
@@ -29,7 +29,7 @@ If you encounter a problem, please file a [Github issue](https://github.com/Micr
 
 ## Requirements
 
-* XCode >= 9.0
+* Xcode >= 9.0
 * Sierra or High Sierra
 * iOS >= 9.0
 

--- a/docs/test-cloud/preparing-for-upload/xcuitest.md
+++ b/docs/test-cloud/preparing-for-upload/xcuitest.md
@@ -17,7 +17,7 @@ The steps necessary to prepare an app and its corresponding test suite for uploa
 
 ## Requirements
 
-* XCode >= 9.0
+* Xcode >= 9.0
 * Sierra or High Sierra
 * iOS >= 9.0
 

--- a/docs/test-cloud/preparing-for-upload/xcuitest.md
+++ b/docs/test-cloud/preparing-for-upload/xcuitest.md
@@ -42,7 +42,6 @@ This will build your app and an XCUITest bundle into the `DerivedData/Build` dir
 ```shell
 $ xcrun xcodebuild -list
 ```
-For a concrete example of generating an app and an XCUITest bundle, see [this shell script that builds for testing](https://github.com/Microsoft/AppCenter-Test-XCUITest-Extensions/blob/master/bin/make/build-for-testing.sh).
 
 ## Uploading Tests to App Center
 


### PR DESCRIPTION
### Motivation

Completes:

* Barefoot Runner [Doc] appcenter.ms needs XCTestContext examples [Azure DevOps](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/39137)

The examples are already there, but the deprecation notice is not strong enough.

Related:

* https://github.com/Microsoft/AppCenter-Test-XCUITest-Extensions/pull/8

### TODO

#### Page Title

The title `Preparing XCUITest Tests for Upload with Extensions` is confusing.  The instructions are not for _any_ extensions (which a developer might understand as a .framework) - the instructions are for a specific .framework.  I think the title should be something like `Preparing XCUITest Tests for Upload with App Center Extensions Framework`.

#### Using XCTestContext + screenshot effectively

In the [pull request](https://github.com/Microsoft/AppCenter-Test-XCUITest-Extensions/pull/8) mentioned above, I have included these details:

```
// Gestures always generate a screenshot which will appear in your test report.
[self.app.buttons[@"Library"] tap];

...

// Queries do not generate screenshots.
// Take a screenshot before assertions to make your test report more readable.
XCUIScreenshot *screenshot = [[XCUIScreen mainScreen] screenshot];
XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
[attachment setLifetime:XCTAttachmentLifetimeKeepAlways];
[activity addAttachment:attachment];
XCTAssertNotNil(self.app.tables[@"favorite Songs"]);
```

I think this content needs to be added to the xcuitest.md page, but I could use some help fitting this information into the existing content.


 