### PR TITLE
Add Better Region Example to SetCountryCode

### DIFF
--- a/docs/sdk/analytics/uwp.md
+++ b/docs/sdk/analytics/uwp.md
@@ -38,7 +38,7 @@ Country code is not automatically reported by the UWP SDK. If you want to report
 AppCenter.SetCountryCode(new Windows.Globalization.GeographicRegion().CodeTwoLetter);
 ```
 
-[GeographicRegion](https://docs.microsoft.com/en-us/uwp/api/windows.globalization.geographicregion) will report the user's home region they currently have selected.
+[GeographicRegion](https://docs.microsoft.com/en-us/uwp/api/windows.globalization.geographicregion) will report the user's home region they have manually selected.  You may want to report a more precise value based on their actual location if your app retrives that information for other purposes. 
 
 ## Custom events
 

--- a/docs/sdk/analytics/uwp.md
+++ b/docs/sdk/analytics/uwp.md
@@ -35,8 +35,10 @@ Once you add App Center Analytics to your app and start the SDK, it will automat
 Country code is not automatically reported by the UWP SDK. If you want to report it manually, you can use the following code before `AppCenter.Start(... typeof(Analytics) ...);`:
 
 ```csharp
-AppCenter.SetCountryCode("us");
+AppCenter.SetCountryCode(new Windows.Globalization.GeographicRegion().CodeTwoLetter);
 ```
+
+[GeographicRegion](https://docs.microsoft.com/en-us/uwp/api/windows.globalization.geographicregion) will report the user's home region they currently have selected.
 
 ## Custom events
 


### PR DESCRIPTION
This is to update the UWP doc with the proper guidance on setting the country code for the user based on discussion in issue #54.

This is the recommendation made in the [official sample](https://github.com/Microsoft/AppCenter-SDK-DotNet/blob/master/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/App.xaml.cs) as well.