### PR TITLE
Use System.getenv instead of System.getProperty

### DIFF
--- a/docs/build/android/code-signing.md
+++ b/docs/build/android/code-signing.md
@@ -49,9 +49,9 @@ android {
     signingConfigs {
         releaseSigningConfig {
             storeFile rootProject.file("app/testapp.jks")
-            storePassword System.getProperty("APPCENTER_KEYSTORE_PASSWORD")
-            keyAlias System.getProperty("APPCENTER_KEY_ALIAS")
-            keyPassword System.getProperty("APPCENTER_KEY_PASSWORD")
+            storePassword System.getenv("APPCENTER_KEYSTORE_PASSWORD")
+            keyAlias System.getenv("APPCENTER_KEY_ALIAS")
+            keyPassword System.getenv("APPCENTER_KEY_PASSWORD")
         }
     }
 


### PR DESCRIPTION
Fixes #424

This should be the right sample code to use when using [App Center Build environment variables](https://docs.microsoft.com/en-us/appcenter/build/custom/variables/).