### PR TITLE
Add Kotlin code samples for SDK

### DIFF
--- a/docs/sdk/analytics/android.md
+++ b/docs/sdk/analytics/android.md
@@ -10,6 +10,9 @@ ms.assetid: 5392ac23-465d-464d-a533-262a94cf15c3
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # App Center Analytics
@@ -45,11 +48,18 @@ properties.put("FileName", "favorite.avi");
 
 Analytics.trackEvent("Video clicked", properties);
 ```
+```kotlin
+val properties = hashMapOf("Category" to "Music", "FileName" to "favorite.avi")
+Analytics.trackEvent("Video clicked", properties)
+```
 
 Properties for events are entirely optional – if you just want to track an event, use this sample instead:
 
 ```java
 Analytics.trackEvent("Video clicked");
+```
+```kotlin
+Analytics.trackEvent("Video clicked")
 ```
 
 ## Event priority and persistence
@@ -74,6 +84,12 @@ Analytics.trackEvent("eventName", properties, Flags.PERSISTENCE_CRITICAL);
 
 // If you are using name only, you can pass null as properties.
 ```
+```kotlin
+val properties = hashMapOf("Category" to "Music", "FileName" to "favorite.avi")
+Analytics.trackEvent("Video clicked", properties, Flags.PERSISTENCE_CRITICAL)
+
+// If you are using name only, you can pass null as properties.
+```
 
 ## Pause and resume sending logs
 
@@ -83,6 +99,10 @@ Pausing the event transmission can be useful in scenarios when the app needs to 
 Analytics.pause();
 Analytics.resume();
 ```
+```kotlin
+Analytics.pause()
+Analytics.resume()
+```
 
 ## Enable or disable App Center Analytics at runtime
 
@@ -91,11 +111,17 @@ You can enable and disable App Center Analytics at runtime. If you disable it, t
 ```java
 Analytics.setEnabled(false);
 ```
+```kotlin
+Analytics.setEnabled(false)
+```
 
 To enable App Center Analytics again, use the same API but pass `true` as a parameter.
 
 ```java
 Analytics.setEnabled(true);
+```
+```kotlin
+Analytics.setEnabled(true)
 ```
 
 [!include[](../android-see-async.md)]
@@ -106,6 +132,9 @@ You can also check if App Center Analytics is enabled or not.
 
 ```java
 Analytics.isEnabled();
+```
+```kotlin
+Analytics.isEnabled()
 ```
 
 [!include[](../android-see-async.md)]

--- a/docs/sdk/android-async.md
+++ b/docs/sdk/android-async.md
@@ -38,7 +38,6 @@ future.thenAccept(object : AppCenterConsumer<{ReturnType}> {
     override fun accept(t: {ReturnType}?) {
         // do something with result, this is called back in U.I. thread.
     }
-
 })
 ```
 

--- a/docs/sdk/android-async.md
+++ b/docs/sdk/android-async.md
@@ -10,6 +10,9 @@ ms.assetid: 610b8797-6884-4dd4-bad3-7c05f39b3922
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # Asynchronous APIs in the Android SDK
@@ -29,6 +32,15 @@ future.thenAccept(new AppCenterConsumer<{ReturnType}>() {
     }
 });
 ```
+```kotlin
+val future = {AnyAsyncApi}()
+future.thenAccept(object : AppCenterConsumer<{ReturnType}> {
+    override fun accept(t: {ReturnType}?) {
+        // do something with result, this is called back in U.I. thread.
+    }
+
+})
+```
 
 To avoid blocking UI thread that causes slowing down your application, consider using `thenAccept` with the callback all the time.
 
@@ -45,9 +57,19 @@ AppCenter.isEnabled().thenAccept(new AppCenterConsumer<Boolean>() {
     }
 });
 ```
+```kotlin
+AppCenter.isEnabled().thenAccept(object : AppCenterConsumer<Boolean> {
+    override fun accept(enabled: Boolean?) {
+        Log.d("MyApp", "AppCenter.isEnabled=$enabled")
+    }
+})
+```
 
 Synchronous example:
 
 ```java
 boolean enabled = AppCenter.isEnabled().get();
+```
+```kotlin
+val enabled = AppCenter.isEnabled().get()
 ```

--- a/docs/sdk/android-async.md
+++ b/docs/sdk/android-async.md
@@ -19,7 +19,7 @@ dev_langs:
 
 Asynchronous APIs return a `AppCenterFuture` object instead of returning the result directly.
 
-You can either call `get()` on the future object to synchronously wait for the result or provide a callback like this:
+You can either call `get()` on the future object to synchronously wait for the result or provide a callback like this, filling in the respective return types when calling the desired API:
 
 ```java
 AppCenterFuture<{ReturnType}> future = {AnyAsyncApi}();
@@ -57,11 +57,9 @@ AppCenter.isEnabled().thenAccept(new AppCenterConsumer<Boolean>() {
 });
 ```
 ```kotlin
-AppCenter.isEnabled().thenAccept(object : AppCenterConsumer<Boolean> {
-    override fun accept(enabled: Boolean?) {
-        Log.d("MyApp", "AppCenter.isEnabled=$enabled")
-    }
-})
+AppCenter.isEnabled().thenAccept { enabled -> 
+    Log.d("MyApp", "AppCenter.isEnabled=$enabled")
+}
 ```
 
 Synchronous example:

--- a/docs/sdk/crashes/android.md
+++ b/docs/sdk/crashes/android.md
@@ -121,7 +121,7 @@ Implement this callback if you'd like to decide if a particular crash needs to b
 ```java
 @Override
 public boolean shouldProcess(ErrorReport report) {
-     return true; // return true if the crash report should be processed, otherwise false.
+	return true; // return true if the crash report should be processed, otherwise false.
 }
 ```
 ```kotlin
@@ -243,6 +243,7 @@ public Iterable<ErrorAttachmentLog> getErrorAttachments(ErrorReport report) {
 ```
 ```kotlin
 override fun getErrorAttachments(report: ErrorReport?): MutableIterable<ErrorAttachmentLog> {
+	
 	/* Attach some text. */
 	val textLog = ErrorAttachmentLog.attachmentWithText("This is a text attachment.", "text.txt")
 

--- a/docs/sdk/crashes/android.md
+++ b/docs/sdk/crashes/android.md
@@ -10,6 +10,9 @@ ms.assetid: a9ac95b3-488f-40c5-ad11-99d8da0fa00b
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # App Center Crashes
@@ -35,6 +38,9 @@ App Center Crashes provides you with an API to generate a test crash for easy te
 ```java
 Crashes.generateTestCrash();
 ```
+```kotlin
+Crashes.generateTestCrash()
+```
 
 ## Get more information about a previous crash
 
@@ -47,6 +53,9 @@ At any time after starting the SDK, you can check if the app crashed in the prev
 ```java
 Crashes.hasCrashedInLastSession();
 ```
+```kotlin
+Crashes.hasCrashedInLastSession()
+```
 
 [!include[](../android-see-async.md)]
 
@@ -58,6 +67,9 @@ If your app crashed previously, you can get details about the last crash.
 
 ```java
 Crashes.getLastSessionCrashReport();
+```
+```kotlin
+Crashes.getLastSessionCrashReport()
 ```
 
 [!include[](../android-see-async.md)]
@@ -80,6 +92,12 @@ CrashesListener customListener = new CrashesListener() {
 };
 Crashes.setListener(customListener);
 ```
+```kotlin
+val customListener = object : CrashesListener {
+	// Implement all callbacks here.
+}
+Crashes.setListener(customListener)
+```
 
 In case you are only interested in customizing some of the callbacks, use the `AbstractCrashesListener` instead:
 
@@ -88,6 +106,12 @@ AbstractCrashesListener customListener = new AbstractCrashesListener() {
 	// Implement any callback here as required.
 };
 Crashes.setListener(customListener);
+```
+```kotlin
+val customListener = object : AbstractCrashesListener() {
+	// Implement any callback here as required.
+}
+Crashes.setListener(customListener)
 ```
 
 ### Should the crash be processed?
@@ -98,6 +122,11 @@ Implement this callback if you'd like to decide if a particular crash needs to b
 @Override
 public boolean shouldProcess(ErrorReport report) {
      return true; // return true if the crash report should be processed, otherwise false.
+}
+```
+```kotlin
+override fun shouldProcess(report: ErrorReport?): Boolean {
+	return true
 }
 ```
 
@@ -122,6 +151,11 @@ public boolean shouldAwaitUserConfirmation() {
 	return true;
 }
 ```
+```kotlin
+override fun shouldAwaitUserConfirmation(): Boolean {
+	return true
+}
+```
 
 If you return `true`, your app must obtain (using your own code) the user's permission and message the SDK with the result using the following API:
 
@@ -130,6 +164,11 @@ If you return `true`, your app must obtain (using your own code) the user's perm
 Crashes.notifyUserConfirmation(Crashes.DONT_SEND);
 Crashes.notifyUserConfirmation(Crashes.SEND);
 Crashes.notifyUserConfirmation(Crashes.ALWAYS_SEND);
+```
+```kotlin
+Crashes.notifyUserConfirmation(Crashes.DONT_SEND)
+Crashes.notifyUserConfirmation(Crashes.SEND)
+Crashes.notifyUserConfirmation(Crashes.ALWAYS_SEND)
 ```
 
 As an example you can refer to [our custom dialog example](https://aka.ms/custom-dialog-android).
@@ -146,6 +185,11 @@ public void onBeforeSending(ErrorReport errorReport) {
 	// Your code, e.g. to present a custom UI.
 }
 ```
+```kotlin
+override fun onBeforeSending(report: ErrorReport?) {
+	// Your code, e.g. to present a custom UI.
+}
+```
 
 #### The following callback will be invoked after the SDK sent a crash log successfully.
 
@@ -155,12 +199,22 @@ public void onSendingSucceeded(ErrorReport report) {
 	// Your code, e.g. to hide the custom UI.
 }
 ```
+```kotlin
+override fun onSendingSucceeded(report: ErrorReport?) {
+	// Your code, e.g. to hide the custom UI.
+}
+```
 
 #### The following callback will be invoked if the SDK failed to send a crash log
 
 ```java
 @Override
 public void onSendingFailed(ErrorReport report, Exception e) {
+	// Your code goes here.
+}
+```
+```kotlin
+override fun onSendingFailed(report: ErrorReport?, e: Exception?) {
 	// Your code goes here.
 }
 ```
@@ -180,11 +234,27 @@ public Iterable<ErrorAttachmentLog> getErrorAttachments(ErrorReport report) {
 	Bitmap bitmap = BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher);
 	ByteArrayOutputStream stream = new ByteArrayOutputStream();
 	bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream);
-	byte[] bitMapData = stream.toByteArray();
-	ErrorAttachmentLog binaryLog = ErrorAttachmentLog.attachmentWithBinary(bitMapData, "ic_launcher.jpeg", "image/jpeg");
+	byte[] bitmapData = stream.toByteArray();
+	ErrorAttachmentLog binaryLog = ErrorAttachmentLog.attachmentWithBinary(bitmapData, "ic_launcher.jpeg", "image/jpeg");
 
 	/* Return attachments as list. */
 	return Arrays.asList(textLog, binaryLog);
+}
+```
+```kotlin
+override fun getErrorAttachments(report: ErrorReport?): MutableIterable<ErrorAttachmentLog> {
+	/* Attach some text. */
+	val textLog = ErrorAttachmentLog.attachmentWithText("This is a text attachment.", "text.txt")
+
+	/* Attach app icon. */
+	val bitmap = BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher)
+	val stream = ByteArrayOutputStream()
+	bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+	val bitmapData = stream.toByteArray()
+	val binaryLog = ErrorAttachmentLog.attachmentWithBinary(bitmapData, "ic_launcher.jpeg", "image/jpeg")
+	
+	/* Return attachments as list. */
+	return Arrays.asList(textLog, binaryLog)
 }
 ```
 
@@ -198,12 +268,20 @@ You can enable and disable App Center Crashes at runtime. If you disable it, the
 ```java
 Crashes.setEnabled(false);
 ```
+```kotlin
+Crashes.setEnabled(false)
+```
+
 
 To enable App Center Crashes again, use the same API but pass `true` as a parameter.
 
 ```java
 Crashes.setEnabled(true);
 ```
+```kotlin
+Crashes.setEnabled(true)
+```
+
 
 [!include[](../android-see-async.md)]
 
@@ -213,6 +291,9 @@ You can also check if App Center Crashes is enabled or not:
 
 ```java
 Crashes.isEnabled();
+```
+```kotlin
+Crashes.isEnabled()
 ```
 
 [!include[](../android-see-async.md)]

--- a/docs/sdk/distribute/android.md
+++ b/docs/sdk/distribute/android.md
@@ -58,7 +58,7 @@ The App Center SDK is designed with a modular approach – a developer only need
 
 In order to use App Center, you need to opt in to the module(s) that you want to use, meaning by default no modules are started and you will have to explicitly call each of them when starting the SDK.
 
-Add the Distribute module to your `AppCenter.start()` method to start App Center Distribute service.
+Add the Distribute class to your `AppCenter.start()` method to start App Center Distribute service.
 
 ```java
 AppCenter.start(getApplication(), "{Your App Secret}", Distribute.class);
@@ -67,7 +67,7 @@ AppCenter.start(getApplication(), "{Your App Secret}", Distribute.class);
 AppCenter.start(application, "{Your App Secret}", Distribute::class.java)
 ```
 
-Make sure you have replaced `{Your App Secret}` in the code sample above with your App Secret. Android Studio will automatically suggest the required import statement once you add a reference to the `Distribute` class to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
+Make sure you have replaced `{Your App Secret}` in the code sample above with your App Secret. Android Studio automatically suggests the required import statement once you add a reference to the `Distribute` class to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
 
 ```java
 import com.microsoft.appcenter.AppCenter;

--- a/docs/sdk/distribute/android.md
+++ b/docs/sdk/distribute/android.md
@@ -10,6 +10,9 @@ ms.assetid: 62f0364a-e396-4b22-98f3-8b2d92b5babb
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # App Center Distribute – In-app updates
@@ -55,17 +58,24 @@ The App Center SDK is designed with a modular approach – a developer only need
 
 In order to use App Center, you need to opt in to the module(s) that you want to use, meaning by default no modules are started and you will have to explicitly call each of them when starting the SDK.
 
-Add `Distribute.class` to your `AppCenter.start()` method to start App Center Distribute service.
+Add the Distribute module to your `AppCenter.start()` method to start App Center Distribute service.
 
 ```java
 AppCenter.start(getApplication(), "{Your App Secret}", Distribute.class);
 ```
+```kotlin
+AppCenter.start(application, "{Your App Secret}", Distribute::class.java)
+```
 
-Make sure you have replaced `{Your App Secret}` in the code sample above with your App Secret. Android Studio will automatically suggest the required import statement once you add `Distribute.class` to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
+Make sure you have replaced `{Your App Secret}` in the code sample above with your App Secret. Android Studio will automatically suggest the required import statement once you add a reference to the `Distribute` class to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
 
 ```java
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.distribute.Distribute;
+```
+```kotlin
+import com.microsoft.appcenter.AppCenter
+import com.microsoft.appcenter.distribute.Distribute
 ```
 
 ## Customize or localize the in-app update dialog
@@ -81,6 +91,10 @@ You can customize the default update dialog's appearance by implementing the `Di
 ```java
 Distribute.setListener(new MyDistributeListener());
 AppCenter.start(...);
+```
+```kotlin
+Distribute.setListener(MyDistributeListener())
+AppCenter.start(...)
 ```
 
 Here is an example of the listener implementation that replaces the SDK dialog with a custom one:
@@ -143,6 +157,54 @@ public class MyDistributeListener implements DistributeListener {
     }
 }
 ```
+```kotlin
+import android.app.Activity
+import android.app.AlertDialog
+import com.microsoft.appcenter.distribute.Distribute
+import com.microsoft.appcenter.distribute.DistributeListener
+import com.microsoft.appcenter.distribute.ReleaseDetails
+import com.microsoft.appcenter.distribute.UpdateAction
+
+class MyDistributeListener : DistributeListener {
+
+    override fun onReleaseAvailable(activity: Activity, releaseDetails: ReleaseDetails): Boolean {
+
+        // Look at releaseDetails public methods to get version information, release notes text or release notes URL
+        val versionName = releaseDetails.shortVersion
+        val versionCode = releaseDetails.version
+        val releaseNotes = releaseDetails.releaseNotes
+        val releaseNotesUrl = releaseDetails.releaseNotesUrl
+
+        // Build our own dialog title and message
+        val dialogBuilder = AlertDialog.Builder(activity)
+        dialogBuilder.setTitle("Version $versionName available!") // you should use a string resource instead of course, this is just to simplify example
+        dialogBuilder.setMessage(releaseNotes)
+
+        // Mimic default SDK buttons
+        dialogBuilder.setPositiveButton(
+            com.microsoft.appcenter.distribute.R.string.appcenter_distribute_update_dialog_download
+        ) { dialog, which ->
+            // This method is used to tell the SDK what button was clicked
+            Distribute.notifyUpdateAction(UpdateAction.UPDATE)
+        }
+
+        // We can postpone the release only if the update is not mandatory
+        if (!releaseDetails.isMandatoryUpdate) {
+            dialogBuilder.setNegativeButton(
+                com.microsoft.appcenter.distribute.R.string.appcenter_distribute_update_dialog_postpone
+            ) { dialog, which ->
+                // This method is used to tell the SDK what button was clicked
+                Distribute.notifyUpdateAction(UpdateAction.POSTPONE)
+            }
+        }
+        dialogBuilder.setCancelable(false) // if it's cancelable you should map cancel to postpone, but only for optional updates
+        dialogBuilder.create().show()
+
+        // Return true if you are using your own dialog, false otherwise
+        return true
+    }
+}
+```
 
 As shown in the example, you have to either call `Distribute.notifyUpdateAction(UpdateAction.UPDATE);` or `Distribute.notifyUpdateAction(UpdateAction.POSTPONE);` if your listener returns `true`.
 
@@ -164,10 +226,17 @@ You can enable and disable App Center Distribute at runtime. If you disable it, 
 ```java
 Distribute.setEnabled(false);
 ```
+```kotlin
+Distribute.setEnabled(false)
+```
+
 To enable App Center Distribute again, use the same API but pass `true` as a parameter.
 
 ```java
 Distribute.setEnabled(true);
+```
+```kotlin
+Distribute.setEnabled(true)
 ```
 
 [!include[](../android-see-async.md)]
@@ -178,6 +247,9 @@ You can also check if App Center Distribute is enabled or not:
 
 ```java
 Distribute.isEnabled();
+```
+```kotlin
+Distribute.isEnabled()
 ```
 
 [!include[](../android-see-async.md)]

--- a/docs/sdk/getting-started/android.md
+++ b/docs/sdk/getting-started/android.md
@@ -10,6 +10,9 @@ ms.assetid: ef67ec59-c868-49e7-99e8-42b0399bde92
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # Get Started with Android
@@ -75,6 +78,9 @@ In order to use App Center, you need to opt in to the module(s) that you want to
 ```java
 AppCenter.start(getApplication(), "{Your App Secret}", Analytics.class, Crashes.class);
 ```
+```kotlin
+AppCenter.start(application, "{Your App Secret}", Analytics::class.java, Crashes::class.java)
+```
 
 ### 4.2 Replace the placeholder with your App Secret
 
@@ -93,6 +99,10 @@ For example - If you just want to onboard to App Center Analytics, you should mo
 ```java
 AppCenter.start(getApplication(), "{Your App Secret}", Analytics.class);
 ```
+```kotlin
+AppCenter.start(application, "{Your App Secret}", Analytics::class.java)
+```
+
 
 Android Studio will automatically suggest the required import statements once you insert the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
 
@@ -100,6 +110,11 @@ Android Studio will automatically suggest the required import statements once yo
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.analytics.Analytics;
 import com.microsoft.appcenter.crashes.Crashes;
+```
+```kotlin
+import com.microsoft.appcenter.AppCenter
+import com.microsoft.appcenter.analytics.Analytics
+import com.microsoft.appcenter.crashes.Crashes
 ```
 
 Great, you are all set to visualize Analytics and Crashes data on the portal that the SDK collects automatically.

--- a/docs/sdk/getting-started/android.md
+++ b/docs/sdk/getting-started/android.md
@@ -104,7 +104,7 @@ AppCenter.start(application, "{Your App Secret}", Analytics::class.java)
 ```
 
 
-Android Studio will automatically suggest the required import statements once you insert the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
+Android Studio automatically suggests the required import statements once you insert the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
 
 ```java
 import com.microsoft.appcenter.AppCenter;

--- a/docs/sdk/other-apis/android.md
+++ b/docs/sdk/other-apis/android.md
@@ -171,11 +171,9 @@ AppCenter.start("{Your App Secret}", Analytics.class);
 ```
 ```kotlin
 // Use 20MB for storage.
-AppCenter.setMaxStorageSize(20 * 1024 * 1024).thenAccept(object : AppCenterConsumer<Boolean> {
-    override fun accept(success: Boolean) {
-        // The success parameter is false when the size cannot be honored.
-    }
-})
+AppCenter.setMaxStorageSize(20 * 1024 * 1024).thenAccept {
+    // The success parameter (it) is false when the size cannot be honored.
+}
 
 AppCenter.start(application, "{Your App Secret}", Analytics::class.java)
 ```

--- a/docs/sdk/other-apis/android.md
+++ b/docs/sdk/other-apis/android.md
@@ -123,7 +123,7 @@ App Center allows you to define custom properties as key value pairs in your app
 > [!NOTE]
 > Only devices that have [Push](../push/android.md) successfully registered are matched in audiences.
 
-You can set custom properties by calling the `setCustomProperties()` API. A valid key for custom property should match regular expression pattern `^[a-zA-Z][a-zA-Z0-9]*$`. A custom property's value may be one of the following Java types: `String`, `Number`, `boolean` and `Date`. 
+Set custom properties by calling the `setCustomProperties()` API. A valid key for custom property should match regular expression pattern `^[a-zA-Z][a-zA-Z0-9]*$`. A custom property's value may be one of the following Java types: `String`, `Number`, `boolean` and `Date`. 
 
 ```java
 CustomProperties properties = new CustomProperties();

--- a/docs/sdk/other-apis/android.md
+++ b/docs/sdk/other-apis/android.md
@@ -10,6 +10,9 @@ ms.assetid: d13dd720-93b3-4658-b579-230c8821e292
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # Other Android APIs
@@ -33,6 +36,9 @@ To have as many log messages as possible, use `Log.Verbose`.
 ```java
 AppCenter.setLogLevel(Log.VERBOSE);
 ```
+```kotlin
+AppCenter.setLogLevel(Log.VERBOSE)
+```
 
 ## Identify installations
 
@@ -40,6 +46,9 @@ The App Center SDK creates a UUID for each device once the app is installed. Thi
 
 ```java
 AppCenter.getInstallId();
+```
+```kotlin
+AppCenter.getInstallId()
 ```
 
 [!include[](../android-see-async.md)]
@@ -54,6 +63,9 @@ The App Center SDK supports setting a **user id** that is used to augment crash 
 ```java
 AppCenter.setUserId("your-user-id");
 ```
+```kotlin
+AppCenter.setUserId("your-user-id")
+```
 
 > [!NOTE]
 > Note that the value for the user id is limited to 256 characters.
@@ -65,11 +77,17 @@ If you want to disable all App Center services at once, use the `setEnabled()` A
 ```java
 AppCenter.setEnabled(false);
 ```
+```kotlin
+AppCenter.setEnabled(false)
+```
 
 To enable all services at once again, use the same API but pass `true` as a parameter.
 
 ```java
 AppCenter.setEnabled(true);
+```
+```kotlin
+AppCenter.setEnabled(true)
 ```
 
 [!include[](../android-see-async.md)]
@@ -81,6 +99,9 @@ You can also check if App Center is enabled or not.
 ```java
 AppCenter.isEnabled();
 ```
+```kotlin
+AppCenter.isEnabled()
+```
 
 [!include[](../android-see-async.md)]
 
@@ -90,6 +111,9 @@ You can get the version of App Center SDK that you are currently using.
 
 ```java
 AppCenter.getSdkVersion();
+```
+```kotlin
+AppCenter.getSdkVersion()
 ```
 
 ## Use custom properties
@@ -106,6 +130,11 @@ CustomProperties properties = new CustomProperties();
 properties.set("color", "blue").set("score", 10);
 AppCenter.setCustomProperties(properties);
 ```
+```kotlin
+val properties = CustomProperties()
+properties.set("color", "blue").set("score", 10)
+AppCenter.setCustomProperties(properties)
+```
 
 > [!NOTE]
 > If you set the same custom property more than once, previous values will be overwritten by the last one.
@@ -117,12 +146,17 @@ CustomProperties properties = new CustomProperties();
 properties.clear("score");
 AppCenter.setCustomProperties(properties);
 ```
+```kotlin
+val properties = CustomProperties()
+properties.clear("score")
+AppCenter.setCustomProperties(properties)
+```
 
 ## Storage size
 
 When using the App Center SDK, logs are stored locally on the device. Large logs can take up a lot of space, so you may choose to limit the size of the local database. It is also useful in conjunction with the `pause` and `resume` APIs. If you expect to be paused for a long time, you can use a larger database size to store more events.
 
-You can use the `setMaxStorageSize` API to set the size of the local DB. The API is asynchronous, and the callback is called when you start App Center services. For this reason, `setMaxStorageSize` must be called before your call to `AppCenter.start(...)]`. You may only call the API once.
+You can use the `setMaxStorageSize` API to set the size of the local DB. The API is asynchronous, and the callback is called when you start App Center services. For this reason, `setMaxStorageSize` must be called before your call to `AppCenter.start(...)`. You may only call the API once.
 
 ```java
 // Use 20MB for storage.
@@ -133,7 +167,17 @@ AppCenter.setMaxStorageSize(20 * 1024 * 1024L).thenAccept(new AppCenterConsumer<
         // The success parameter is false when the size cannot be honored.
     }
 });
-AppCenter.start("{your secret}", Analytics.class);
+AppCenter.start("{Your App Secret}", Analytics.class);
+```
+```kotlin
+// Use 20MB for storage.
+AppCenter.setMaxStorageSize(20 * 1024 * 1024).thenAccept(object : AppCenterConsumer<Boolean> {
+    override fun accept(success: Boolean) {
+        // The success parameter is false when the size cannot be honored.
+    }
+})
+
+AppCenter.start(application, "{Your App Secret}", Analytics::class.java)
 ```
 
 If you don't set the max storage size, the SDK uses a default max size of 10MB. The minimum size you are allowed to set is 20KB.

--- a/docs/sdk/push/android.md
+++ b/docs/sdk/push/android.md
@@ -96,7 +96,7 @@ The App Center SDK is designed with a modular approach – a developer only need
 
 In order to use App Center, you need to opt in to the module(s) that you want to use, meaning by default no modules are started and you will have to explicitly call each of them when starting the SDK.
 
-Add the `Push` module to your `AppCenter.start()` method to start App Center Push.
+Add the `Push` class to your `AppCenter.start()` method to start App Center Push.
 
 ```java
 AppCenter.start(getApplication(), "{Your App Secret}", Push.class);
@@ -107,7 +107,7 @@ AppCenter.start(application, "{Your App Secret}", Push::class.java)
 
 Make sure you have replaced `{Your App Secret}` in the code sample above with your App Secret. Please check out the [Get started](~/sdk/getting-started/android.md) section if you haven't set up and started the SDK in your application, yet.
 
-Android Studio will automatically suggest the required import statement once you add `Push` to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
+Android Studio automatically suggests the required import statement once you add `Push` to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
 
 ```java
 import com.microsoft.appcenter.AppCenter;

--- a/docs/sdk/push/android.md
+++ b/docs/sdk/push/android.md
@@ -10,6 +10,9 @@ ms.assetid: 45ba2c1e-55ad-4261-8f59-61e0b8f7edbc
 ms.service: vs-appcenter
 ms.custom: sdk
 ms.tgt_pltfrm: android
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # App Center Push
@@ -93,19 +96,26 @@ The App Center SDK is designed with a modular approach – a developer only need
 
 In order to use App Center, you need to opt in to the module(s) that you want to use, meaning by default no modules are started and you will have to explicitly call each of them when starting the SDK.
 
-Add `Push.class` to your `AppCenter.start()` method to start App Center Push.
+Add the `Push` module to your `AppCenter.start()` method to start App Center Push.
 
 ```java
 AppCenter.start(getApplication(), "{Your App Secret}", Push.class);
 ```
+```kotlin
+AppCenter.start(application, "{Your App Secret}", Push::class.java)
+```
 
 Make sure you have replaced `{Your App Secret}` in the code sample above with your App Secret. Please check out the [Get started](~/sdk/getting-started/android.md) section if you haven't set up and started the SDK in your application, yet.
 
-Android Studio will automatically suggest the required import statement once you add `Push.class` to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
+Android Studio will automatically suggest the required import statement once you add `Push` to the `start()` method, but if you see an error that the class names are not recognized, add the following lines to the import statements in your activity class:
 
 ```java
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.push.Push;
+```
+```kotlin
+import com.microsoft.appcenter.AppCenter
+import com.microsoft.appcenter.push.Push
 ```
 
 ## Intercept push notifications
@@ -129,15 +139,25 @@ You need to register the listener before calling `AppCenter.start` as shown in t
 Push.setListener(new MyPushListener());
 AppCenter.start(...);
 ```
+```kotlin
+Push.setListener(MyPushListener())
+AppCenter.start(...)
+```
 
 If (**and only if**) your launcher activity uses a `launchMode` of `singleTop`, `singleInstance` or `singleTask`, you need to add this in the activity `onNewIntent` method:
 
 ```java
-    @Override
-    protected void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        Push.checkLaunchedFromNotification(this, intent);
-    }
+@Override
+protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    Push.checkLaunchedFromNotification(this, intent);
+}
+```
+```kotlin
+override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    Push.checkLaunchedFromNotification(this, intent)
+}
 ```
 
 Here is an example of the listener implementation that displays an alert dialog if the message is received in foreground or a toast if a background push has been clicked:
@@ -176,7 +196,46 @@ public class MyPushListener implements PushListener {
             Toast.makeText(activity, String.format(activity.getString(R.string.push_toast), customData), Toast.LENGTH_LONG).show(); // For example R.string.push_toast would be "Push clicked with data=%1s"
         }
     }
-});
+}
+```
+```kotlin
+class MyPushListener : PushListener {
+
+    override fun onPushNotificationReceived(activity: Activity, pushNotification: PushNotification) {
+
+        /* The following notification properties are available. */
+        val title = pushNotification.getTitle()
+        val message = pushNotification.getMessage()
+        val customData = pushNotification.getCustomData()
+
+        /*
+         * Message and title cannot be read from a background notification object.
+         * Message being a mandatory field, you can use that to check foreground vs background.
+         */
+        if (message != null) {
+
+            /* Display an alert for foreground push. */
+            val dialog = AlertDialog.Builder(activity)
+            if (title != null) {
+                dialog.setTitle(title)
+            }
+            dialog.setMessage(message)
+            if (!customData.isEmpty()) {
+                dialog.setMessage(message + "\n" + customData)
+            }
+            dialog.setPositiveButton(android.R.string.ok, null)
+            dialog.show()
+        } else {
+
+            /* Display a toast when a background push is clicked. */
+            Toast.makeText(
+                activity,
+                String.format(activity.getString(R.string.push_toast), customData),
+                Toast.LENGTH_LONG
+            ).show() // For example R.string.push_toast would be "Push clicked with data=%1s"
+        }
+    }
+}
 ```
 
 ## Custom data in your notifications
@@ -203,10 +262,17 @@ You can enable and disable App Center Push at runtime. If you disable it, the SD
 ```java
 Push.setEnabled(false);
 ```
+```kotlin
+Push.setEnabled(false)
+```
+
 To enable App Center Push again, use the same API but pass `true` as a parameter.
 
 ```java
 Push.setEnabled(true);
+```
+```kotlin
+Push.setEnabled(true)
 ```
 
 [!include[](../android-see-async.md)]
@@ -217,6 +283,9 @@ You can also check if App Center Push is enabled or not:
 
 ```java
 Push.isEnabled();
+```
+```kotlin
+Push.isEnabled()
 ```
 
 [!include[](../android-see-async.md)]

--- a/docs/sdk/troubleshooting/android.md
+++ b/docs/sdk/troubleshooting/android.md
@@ -9,6 +9,9 @@ ms.topic: article
 ms.assetid: 4ad55002-05c9-4f5b-82b7-d29ba1234ce1
 ms.service: vs-appcenter
 ms.custom: sdk
+dev_langs:
+ - java
+ - kotlin
 ---
 
 # Android SDK Troubleshooting
@@ -41,6 +44,9 @@ None of these permissions require user approval at runtime, those are all instal
    ```java
    AppCenter.setLogLevel(Log.VERBOSE);
    ```
+   ```kotlin
+   AppCenter.setLogLevel(Log.VERBOSE)
+   ```
 
    Check the logs say "App Center SDK configured successfully" (in Info log level), then check if you see HTTPS request logs.
 
@@ -57,6 +63,9 @@ None of these permissions require user approval at runtime, those are all instal
 
    ```java
    AppCenter.setLogLevel(Log.VERBOSE);
+   ```
+   ```kotlin
+   AppCenter.setLogLevel(Log.VERBOSE)
    ```
 
    Check the logs say "App Center SDK configured successfully" (in Info log level), then check if you see HTTPS request logs.


### PR DESCRIPTION
Adds Kotlin code samples for setting up and using the App Center SDK features for Android apps.

Also fixes some small issues and inconsistencies with the Java code samples.