### PR TITLE
Update appium documentation for upcoming appium upgrade.  

### DIFF
--- a/docs/test-cloud/preparing-for-upload/appium.md
+++ b/docs/test-cloud/preparing-for-upload/appium.md
@@ -20,7 +20,7 @@ Note the following limitations for Appium support:
 * No support for TestNG.
 * No support for Android 4.2 or prior.
 * Maven version must be at least 3.3.9.
-* Support for Appium version 1.11.0 only. This appium version requires at the appium java client to be at least 6.0.0  
+* Support for Appium version 1.11.0 only. This appium version requires the appium java client to be at least 6.0.0  
 * JUnit 4.9 - 4.12 is supported; we don't support JUnit 5.
 * Automating browsers or WebView context is not supported.
 * Tests must target precisely one app. (`MobileCapabilityType.FULL_RESET` is supported)


### PR DESCRIPTION
Not to be merged before appium 1.11 support has shipped!

* Update supported appium version
* Remove gradle section
* Update extension version
* we now supports fullReset. 
* clarify Re-installation speedup