### PR TITLE
[WIP] Remove outdated GCM instructions

### DIFF
--- a/docs/sdk/push/migration/xamarin-android.md
+++ b/docs/sdk/push/migration/xamarin-android.md
@@ -4,7 +4,7 @@ description: Contains instructions for how to configure your project to use Fire
 keywords: sdk, push
 author: elamalani
 ms.author: emalani
-ms.date: 10/19/2018
+ms.date: 04/22/2019
 ms.topic: article
 ms.assetid: f8a120ed-d217-4e01-9811-685a1c64c498
 ms.service: vs-appcenter
@@ -24,7 +24,7 @@ If you are using App Center Build, you must make sure Mono version is 5.8 or hig
 
 ## 2. AndroidManifest.xml
 
-Edit the project's **AndroidManifest.xml** file and remove the following lines in <application> section, if present:
+Edit the project's `AndroidManifest.xml` file and remove the following lines in the `<application>` section, if present:
 
 ```xml
 <application ...>
@@ -48,7 +48,7 @@ Edit the project's **AndroidManifest.xml** file and remove the following lines i
 </application>
 ```
 
-Remove the following lines from the project's **AndroidManifest.xml** file:
+Remove the following lines from the project's `AndroidManifest.xml` file:
 
 ```xml
 <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
@@ -61,26 +61,26 @@ Remove the following lines from the project's **AndroidManifest.xml** file:
 * Click on the project corresponding to your application.
 * Go to **Project settings** (using the cog icon).
 * Find your application in the list.
-* Download the **google-services.json** file.
-* Copy **google-services.json** file into the root of your Android specific project using Visual Studio so that the file is visible in the solution.
+* Download the `google-services.json` file.
+* Copy the `google-services.json` file into the root of your Android specific project using Visual Studio so that the file is visible in the solution.
 * Close and reopen your solution.
 * The next step depends if you are on Mac or Windows:
-    * On Visual Studio for Mac, open the context menu on the **google-services.json** file then select **GoogleServicesJson** in **Build Action**.
-    * On Visual Studio for Windows, select the **google-services.json** file in the Solution explorer. In **Properties > Advanced > Build Action**, select **GoogleServicesJson**.
+    * On Visual Studio for Mac, open the context menu on the `google-services.json` file then select **GoogleServicesJson** in **Build Action**.
+    * On Visual Studio for Windows, select the project's `google-services.json` file in the Solution explorer. In **Properties > Advanced > Build Action**, select **GoogleServicesJson**.
 
 ## 4. ProGuard
 
-If you are using ProGuard, you must update the rules in the **proguard.cfg** file.
+If you are using ProGuard, you must update the rules in the `proguard.cfg` file.
 
 Remove the following line:
 
-```
+```text
 -dontwarn com.microsoft.appcenter.push.**
 ```
 
 And add the following lines:
 
-```
+```text
 -dontwarn com.google.android.gms.**
 -keep class com.google.firebase.provider.FirebaseInitProvider
 -keep class com.google.firebase.iid.FirebaseInstanceIdReceiver

--- a/docs/sdk/push/migration/xamarin-android.md
+++ b/docs/sdk/push/migration/xamarin-android.md
@@ -24,7 +24,7 @@ If you are using App Center Build, you must make sure Mono version is 5.8 or hig
 
 ## 2. AndroidManifest.xml
 
-Edit the project's **AndroidManifest.xml** file, then insert the following lines **inside** the <application> section:
+Edit the project's **AndroidManifest.xml** file and remove the following lines in <application> section, if present:
 
 ```xml
 <application ...>

--- a/docs/sdk/push/xamarin-android.md
+++ b/docs/sdk/push/xamarin-android.md
@@ -59,7 +59,7 @@ Please follow the [Get started](~/sdk/getting-started/xamarin.md) section if you
 
 ### 4. Modify the project's AndroidManifest.xml file
 
-Edit the project's **AndroidManifest.xml** file, then insert the following lines **inside** the <application> section:
+If you're migrating from Google Cloud Messaging to Firebase, your project's **AndroidManifest.xml** file might contain outdated GCM configuration which may cause notification duplication. Edit the file and remove the following lines in the <application> section, if present:
 
 ```xml
 <application ...>
@@ -82,6 +82,7 @@ Edit the project's **AndroidManifest.xml** file, then insert the following lines
 
 </application>
 ```
+If your project's **AndroidManifest.xml** already doesn't contain these lines, then there's no additional changes required to the file.
 
 ### 5. Customize ProGuard configuration
 

--- a/docs/sdk/push/xamarin-android.md
+++ b/docs/sdk/push/xamarin-android.md
@@ -6,7 +6,7 @@ description: Integrating App Center Push into Xamarin.Android applications
 keywords: sdk, push
 author: elamalani
 ms.author: emalani
-ms.date: 03/22/2019
+ms.date: 04/22/2019
 ms.topic: article
 ms.assetid: 3f3e83cd-0f05-455e-8e67-6b6d5042949d
 ms.service: vs-appcenter
@@ -51,15 +51,15 @@ Please follow the [Get started](~/sdk/getting-started/xamarin.md) section if you
 
 ### 3. Add google-services.json
 
-* Copy **google-services.json** file into the root of your Android specific project using Visual Studio so that the file is visible in the solution.
+* Copy the `google-services.json` file into the root of your Android specific project using Visual Studio so that the file is visible in the solution.
 * Close and reopen your solution. 
 * The next step depends if you are on Mac or Windows:
-    * On Visual Studio for Mac, open the context menu on the **google-services.json** file then select **GoogleServicesJson** in **Build Action**.
+    * On Visual Studio for Mac, open the context menu on the `google-services.json` file then select **GoogleServicesJson** in **Build Action**.
     * On Visual Studio for Windows, select the **google-services.json** file in the Solution explorer. In **Properties > Advanced > Build Action**, select **GoogleServicesJson**.
 
 ### 4. Modify the project's AndroidManifest.xml file
 
-If you're migrating from Google Cloud Messaging to Firebase, your project's **AndroidManifest.xml** file might contain outdated GCM configuration which may cause notification duplication. Edit the file and remove the following lines in the <application> section, if present:
+If you're migrating from Google Cloud Messaging to Firebase, your project's `AndroidManifest.xml` file might contain outdated GCM configuration which may cause notification duplication. Edit the file and remove the following lines in the <application> section, if present:
 
 ```xml
 <application ...>
@@ -82,7 +82,7 @@ If you're migrating from Google Cloud Messaging to Firebase, your project's **An
 
 </application>
 ```
-If your project's **AndroidManifest.xml** already doesn't contain these lines, then there's no additional changes required to the file.
+If your project's `AndroidManifest.xml doesn't contain these lines, then there's no additional changes required to the file.
 
 ### 5. Customize ProGuard configuration
 
@@ -93,15 +93,15 @@ If you're using ProGuard, you must customize the project's configuration for Pus
 > [!NOTE]
 > If you don't use ProGuard or if you already have a ProGuard configuration file in your project, you may skip this section.
 
-Add an empty file to your Xamarin.Android project named *proguard.cfg*. Set the build action to "ProguardConfiguration."
+Add an empty file to your Xamarin.Android project named *proguard.cfg*. Set the build action to **ProguardConfiguration**.
 
 ![proguard-configuration-build-action](images/proguard-configuration-build-action.png)
 
 #### 5.2. Add customization to ProGuard configuration file
 
-In your Xamarin.Android project, add the following line to your `proguard.cfg` file:
+In your Xamarin.Android project, add the following line to the project's `proguard.cfg` file:
 
-```
+```text
 -dontwarn com.microsoft.appcenter.**
 -dontwarn com.google.android.gms.**
 -keep class com.google.firebase.provider.FirebaseInitProvider
@@ -113,7 +113,7 @@ In your Xamarin.Android project, add the following line to your `proguard.cfg` f
 
 ### Additional setup
 
-If (**and only if**) your launcher activity uses a `launchMode` of `singleTop`, `singleInstance` or `singleTask`, you need to add this in the activity `onNewIntent` method:
+If (**and only if**) your launcher activity uses a `launchMode` of `singleTop`, `singleInstance` or `singleTask`, you must add this in the activity's `onNewIntent` method:
 
 ```csharp
         protected override void OnNewIntent(Android.Content.Intent intent)


### PR DESCRIPTION
Removes instruction to update AndroidManifest.xml file with GCM-related configuration which caused notification duplication when used with Firebase.