### PR TITLE
Removed warning about NUnit3 Support

### DIFF
--- a/docs/test-cloud/preparing-for-upload/uitest.md
+++ b/docs/test-cloud/preparing-for-upload/uitest.md
@@ -17,9 +17,6 @@ ms.custom: test
 The steps necessary to prepare an app and its corresponding test suite for upload
 to App Center vary depending on the test framework. The section below provides instructions for preparing Xamarin.UITests for upload to App Center Test.
 
-> [!NOTE]
-> Xamarin.UITest requires NUnit 2.6.3 or 2.6.4 to run tests. Xamarin.UITest is not compatible with NUnit 3.x.
-
 ## Preparing Xamarin.Android Apps
 
 > [!IMPORTANT]


### PR DESCRIPTION
With the release of Xamarin.UITest v3.0, it now has NUnit 3 support: 
https://www.nuget.org/packages/Xamarin.UITest/