### PR TITLE
Update links and use Partner Center name.

### DIFF
--- a/docs/diagnostics/windows-support.md
+++ b/docs/diagnostics/windows-support.md
@@ -68,9 +68,9 @@ You also might notice some features you see in other platforms are missing for y
 
 ### Submitting your app to the Microsoft Store
 
-To submit your app through the Microsoft Store, you must create an app package file and submit the package to [Microsoft Dev Center](https://developer.microsoft.com/en-us/windows). In creating your package file, you can include symbol files to upload to Dev Center. This will allow App Center to display symbolicated stack traces. 
+To distribute your app through the Microsoft Store, you must create an app package file and [submit the package](https://docs.microsoft.com/windows/uwp/publish/upload-app-packages) to [Partner Center](https://partner.microsoft.com/dashboard). In creating your package file, you can include symbol files to upload to Partner Center. This will allow App Center to display symbolicated stack traces. 
 
-Follow the [Windows packaging documentation](https://docs.microsoft.com/en-us/windows/uwp/packaging/packaging-uwp-apps#create-an-app-package-upload-file) to package your app. 
+Follow the [Windows packaging documentation](https://docs.microsoft.com/windows/uwp/packaging/index) to package your app.
 
  
 ## WinForms, WinRT, WPF, and Silverlight 


### PR DESCRIPTION
Note: The UWP docs refer to it as "Partner Center" rather than "the Partner Center".