### PR TITLE
Update React Native docs for RN 0.60 for single modules

### DIFF
--- a/docs/sdk/auth/react-native.md
+++ b/docs/sdk/auth/react-native.md
@@ -34,13 +34,11 @@ Open your terminal and navigate to the root directory of your React Native proje
 npm install appcenter-auth --save-exact
 ```
 
-### 2. Link the SDK
+### 2. Integrate the SDK automatically
 
-Link the plugins to the React Native app using the react-native link command:
+Integrate React Native iOS only:
 
-```bash
-react-native link appcenter-auth
-```
+Run `pod install` from iOS directory to install CocoaPods dependencies.
 
 ### 3. Android 
 

--- a/docs/sdk/push/react-native-android.md
+++ b/docs/sdk/push/react-native-android.md
@@ -40,19 +40,11 @@ ms.tgt_pltfrm: react-native
 Please follow the [Get started](~/sdk/getting-started/react-native.md) section if you haven't set up and started the SDK in your application, yet.
 The App Center SDK is designed with a modular approach – you only need to integrate the services that you're interested in.
 
-1. Open a Terminal and navigate to the root of your React Native project, then enter the following to add App Center Push to the app:
+- Open a Terminal and navigate to the root of your React Native project, then enter the following to add App Center Push to the app:
 
     ```
     npm install appcenter-push --save-exact
     ```
-
-2. Link the plugin to the React Native app by using the react-native link command.
-
-    ```
-    react-native link appcenter-push
-    ```
-
-    Those steps modify the project's `MainApplication.java` file, adding `AppCenterReactNativePushPackage` there.
 
 ## Integrate Firebase in your application
 

--- a/docs/sdk/push/react-native-ios.md
+++ b/docs/sdk/push/react-native-ios.md
@@ -70,11 +70,7 @@ The default integration of the SDK uses Cocoapods for iOS.
    npm install appcenter-push --save-exact
    ```
 
-2. Link the plugin to the React Native app by using the `react-native link command`.
-
-   ```
-   react-native link appcenter-push
-   ```
+2. Run `pod install` from iOS directory to install CocoaPods dependencies.
 
 #### Integrate the iOS SDK manually
 


### PR DESCRIPTION
## Description

Update Auth and Push modules for RN 0.60.
`react-native link` is not required for RN apps with version 0.60 and higher, but it requires to re-run `pod install` for ios.

## Related PRs or issues
#[65703](https://dev.azure.com/msmobilecenter/Mobile-Center/_queries/edit/65703/?triage=true)
