### PR TITLE
Fix sentence typo

### DIFF
--- a/docs/distribution/installation.md
+++ b/docs/distribution/installation.md
@@ -17,7 +17,7 @@ Installation of an application being distributed by App Center begins with an em
 
 ## Windows and Certificates Requirements
 
-To install a windows package requires a trusted root certificate installed in the root certificate chain for the device you are installing too. The most common solution is for the developer to sign a application package with a purchased 3rd party provider trusted root certificate. This certificate will chain to through the third party to the Microsoft root store and so will be a trusted cert for all user devices. Developers can opt to use a self-created test certificate and sign the application package, however it will result in additional steps for testers at installation time.
+To install a windows package requires a trusted root certificate installed in the root certificate chain for the device you are installing too. The most common solution is for the developer to sign a application package with a purchased 3rd party provider trusted root certificate. This certificate will chain through the third party to the Microsoft root store, and so will be a trusted cert for all user devices. Developers can opt to use a self-created test certificate and sign the application package, however it will result in additional steps for testers at installation time.
 
 #### Installing a build signed with a developer test certificate
 


### PR DESCRIPTION
Hard to tell in the GitHub diff, but here's the change at this point:

New:

> This certificate will chain through the third party to the Microsoft root store, and so will be a trusted cert for all user devices.

Original (change area highlighted):

> This certificate will _chain to through the third party to the Microsoft root store_ and so will be a trusted cert for all user devices.
