### PR TITLE
Update requirements for App Center Distribute

### DIFF
--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -71,7 +71,7 @@ Analytics        | 4.1 and later      | 16 and later
 Auth             | 4.1 and later      | 16 and later
 Crashes          | 4.1 and later      | 16 and later
 Data             | 4.1 and later      | 16 and later
-Distribute       | 4.1 and later      | 16 and later
+Distribute       | 4.4 and later      | 19 and later
 Push             | 4.1 and later      | 16 and later
 
 ### iOS


### PR DESCRIPTION
Release notes for App Center 2.4.0 updates minSdkVersion: https://github.com/microsoft/appcenter-sdk-android/releases/tag/2.4.0