### PR TITLE
use correct term for "using directive"

### DIFF
--- a/docs/sdk/getting-started/uwp.md
+++ b/docs/sdk/getting-started/uwp.md
@@ -86,7 +86,7 @@ In Visual Studio solution explorer, double-click the **Package.appxmanifest** fi
 
 In order to use App Center, you must opt in to the module(s) that you want to use. By default no modules are started and you will have to explicitly call each of them when starting the SDK.
 
-### 5.1 Add the using statements
+### 5.1 Add the using directives
 
 Add the appropriate namespaces before you use our APIs.
 


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).