### PR TITLE
Suggestion: Updated React Native build script examples

### DIFF
--- a/docs/build/react-native/Android/index.md
+++ b/docs/build/react-native/Android/index.md
@@ -127,16 +127,28 @@ The [Yarn package manager](https://yarnpkg.com) is a faster, more deterministic 
 
 ### 6.2. Custom build scripts
 
-In addition to App Center's [custom build scripts](~/build/custom/scripts/index.md) you might want to use [npm-scripts](https://docs.npmjs.com/misc/scripts) for example when your React Native app uses TypeScript and you have to run the `tsc` compiler at build start. Add a `postinstall` script in the `package.json` like this:
+There are several options for running scripts before App Center's default build commands are executed.
 
-```javascript
-  "scripts": {
-    ...
-    "postinstall" : "./postinstall.sh"     [other examples: "node ./postinstall.js" or just a single command like "tsc"]
-  },
-```
+- Create a [postinstall](https://docs.npmjs.com/misc/scripts#examples) script in your project's `package.json` file. This will automatically execute after your dependencies are installed.
 
-Postinstall scripts run right after all the `package.json` packages are installed, so you use those packages in your script.
+  ```javascript
+    "scripts": {
+      ...
+      "postinstall" : "npx jetify" // other examples: "node ./postinstall.js" or "./postinstall.sh"
+    },
+  ```
+
+- Write a shell script using App Center's [custom build scripts](~/build/custom/scripts/index.md) functionality.
+
+  ```shell
+  #!/usr/bin/env bash
+
+  # Example: Authenticate with private NPM registry
+  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+
+  # Example: Add your signing key file (from base64 encoded environment variable)
+  base64 -d <<< "$ANDROID_JSON_KEY_FILE" > android/keystores/json_key_file.json
+  ```
 
 ### 6.3. Building multiple APKs
 

--- a/docs/build/react-native/iOS/index.md
+++ b/docs/build/react-native/iOS/index.md
@@ -114,13 +114,26 @@ If this app has the crashes SDK integrated, iOS symbols and source maps will be 
 [Yarn](https://yarnpkg.com) is a faster, more deterministic replacement for `npm`. If a `yarn.lock` file is present in your repo next to `package.json`, then App Center will use Yarn, doing `yarn install` at the start of the build. Otherwise, it will do `npm install`.
 
 ### 5.2. Custom build scripts
-In addition to App Center's [custom build scripts](~/build/custom/scripts/index.md), you might want to use [npm-scripts](https://docs.npmjs.com/misc/scripts). For example, when your React Native app uses TypeScript and you need to run the `tsc` compiler at build start. Add a `postinstall` script in the `package.json` like this:
 
-```javascript
-  "scripts": {
-    ...
-    "postinstall" : "./postinstall.sh"     [other examples: "node ./postinstall.js" or just a single command like "tsc"]
-  },
-```
+There are several options for running scripts before App Center's default build commands are executed.
 
-Postinstall scripts run right after all the `package.json` packages are installed, so you use those packages in your script.
+- Create a [postinstall](https://docs.npmjs.com/misc/scripts#examples) script in your project's `package.json` file. This will automatically execute after your dependencies are installed.
+
+  ```javascript
+    "scripts": {
+      ...
+      "postinstall" : "eslint ./" // other examples: "node ./postinstall.js" or "./postinstall.sh"
+    },
+  ```
+
+- Write a shell script using App Center's [custom build scripts](~/build/custom/scripts/index.md) functionality.
+
+  ```shell
+  #!/usr/bin/env bash
+
+  # Example: Authenticate with private NPM registry
+  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+
+  # Example: Create a file that's not in version control (from base64 encoded environment variable)
+  base64 -d <<< "$MY_FILE_CONTENTS" > ios/SuperSecretFile.txt
+  ```


### PR DESCRIPTION
Hey all,

I've added a few extra examples to the "Custom build scripts" section of the React Native build script documentation. I personally feel like these are a better representation of the kinds of tasks people are looking to perform in CI for React Native projects.

The existing `tsc` example is not something that should be common (or possibly even encouraged?), as the [Default React Native Babel Config](https://www.npmjs.com/package/metro-react-native-babel-preset) automatically compiles TypeScript during an iOS & Android build. The "official" [Typescript React Native App](https://github.com/microsoft/TypeScript-React-Native-Starter) doesn't use this either.

### Brief list of changes:

1. Added an `npx jetify` example for Android (a process used to ensure old android packages are converted to work with Android X).
2. Added an example of authenticating with a private npm registry.
3. Added an example of creating secret files which aren't in version control, such as an android signing key.

^ In regards to 3, we use a similar script to also create the `appcenter-config.json` and `AppCenter-Config.plist` files in CI, but I'm not sure if that's something you want to encourage people to do so I left it out of the examples!

Cheers,

Adam.