### PR TITLE
JavaScript stack traces are not available for Android (React Native)

### DIFF
--- a/docs/sdk/crashes/react-native.md
+++ b/docs/sdk/crashes/react-native.md
@@ -53,6 +53,9 @@ throw new Error('This is a test javascript crash!');
 > Your React Native app needs to be compiled in **release mode** for this crash to be sent to App Center.
 
 > [!NOTE]
+> At this time, JavaScript stack traces are only supported for iOS. This includes uncaught exceptions. You can read more about this limitation [here](https://github.com/microsoft/appcenter/issues/75).
+
+> [!NOTE]
 > It is best practice to avoid JavaScript `throw` statement with a string value (e.g.: `throw 'message'`), as [React Native doesn't preserve full JavaScript stack](https://github.com/facebook/react-native/blob/v0.57.1/Libraries/Core/ExceptionsManager.js#L67-L71) in this scenario. Please `throw` a JavaScript `Error` (e.g.: `throw Error('message')`) instead.
 
 ## Get more information about a previous crash

--- a/docs/sdk/crashes/react-native.md
+++ b/docs/sdk/crashes/react-native.md
@@ -53,7 +53,7 @@ throw new Error('This is a test javascript crash!');
 > Your React Native app needs to be compiled in **release mode** for this crash to be sent to App Center.
 
 > [!NOTE]
-> At this time, JavaScript stack traces are only supported for iOS. This includes uncaught exceptions. You can read more about this limitation [here](https://github.com/microsoft/appcenter/issues/75).
+> At this time, App Center does not support source maps to unminify JavaScript stack traces for Android React Native apps.
 
 > [!NOTE]
 > It is best practice to avoid JavaScript `throw` statement with a string value (e.g.: `throw 'message'`), as [React Native doesn't preserve full JavaScript stack](https://github.com/facebook/react-native/blob/v0.57.1/Libraries/Core/ExceptionsManager.js#L67-L71) in this scenario. Please `throw` a JavaScript `Error` (e.g.: `throw Error('message')`) instead.


### PR DESCRIPTION
There is currently a critical limitation for Android React Native crash reports which has no fix or timeline planned.

It's essentially impossible to diagnose uncaught exceptions and other common errors which arise from JavaScript since there is no option to generate or upload a sourcemap. This is a feature that was created for iOS but not Android (yet).

You can see screenshots and other examples [in this issue thread](https://github.com/microsoft/appcenter/issues/75#issuecomment-620682197).