### PR TITLE
Fixing NotificationHub.initialize parameter order

### DIFF
--- a/docs/migration/push/index.md
+++ b/docs/migration/push/index.md
@@ -84,8 +84,8 @@ Azure Notification Hubs SDK will be initialized with the application, default Li
 ```
 NotificationHub.initialize(
     this.getApplication()
-    "{Connection String}", 
-    "{Hub Name}"
+    "{Hub Name}",
+    "{Connection String}"
 );
 ```
 

--- a/docs/migration/push/index.md
+++ b/docs/migration/push/index.md
@@ -98,7 +98,7 @@ NotificationHub.setListener(new NotificationListener() {
     }
 });
 
-NotificationHub.initialize(this.getApplication(), "{Connection String}", "{Hub Name}"));
+NotificationHub.initialize(this.getApplication(), "{Hub Name}", "{Connection String}"));
 ```
 This interface has a single method, which allows you to process the incoming custom NotificationMessage instance via the onNotificationReceived method. 
 ```


### PR DESCRIPTION
I noticed a difference between the order of the parameters in the migration guide and in our SDK.

[v1.0.0-preview1, NotificationHub.java#L62](https://github.com/Azure/azure-notificationhubs-android/blob/v1.0.0-preview1/notification-hubs-sdk/src/main/java/com/microsoft/windowsazure/messaging/notificationhubs/NotificationHub.java#L62)