### PR TITLE
Update iOS for AppCenterPush migration

### DIFF
--- a/docs/migration/push/index.md
+++ b/docs/migration/push/index.md
@@ -16,7 +16,7 @@ Microsoft recently [announced](https://devblogs.microsoft.com/appcenter/app-cent
 + We're committed to continuing the developer experience that made App Center Push a compelling offering. 
 + We want to make the migration process from App Center Push to Azure Notification Hubs as seamless as possible.
 
-To help with these goals, we've released a new [preview release of the Notification Hubs Android SDK](https://go.microsoft.com/fwlink/?linkid=2128633) and created this migration guide to help you get started with the transition.
+To help with these goals, we've released new preview releases of the Notification Hubs [Android SDK](https://go.microsoft.com/fwlink/?linkid=2128633) and [iOS SDK](https://go.microsoft.com/fwlink/?linkid=2129045), and created this migration guide to help you get started with the transition.
 
 ## Benefits of Azure Notification Hubs
 Azure Notification Hubs offers many benefits to mobile app developers:
@@ -79,7 +79,7 @@ repositories {
 
 **On iOS** 
 
-The Azure Notification Hubs SDK for iOS can be obtained a number of ways including CocoaPods, and direct download and integration.  Once the Azure Notification Hubs SDK release is final, it will be available via Carthage and the Swift Package Manager (SPM).
+The Azure Notification Hubs SDK for iOS can be obtained in a number of ways, including CocoaPods, and direct download and integration.  Once the Azure Notification Hubs SDK release is final, it will be available via Carthage and the Swift Package Manager (SPM).
 
 #### Integration via CocoaPods
 
@@ -91,9 +91,9 @@ pod 'AzureNotificationHubs-iOS'
 
 #### Integration by copying binaries into your project
 
-- Download the [Azure Notification Hubs SDK](https://github.com/Azure/azure-notificationhubs-ios/releases) framework provided as a zip file and unzip it.
+- Download the [Azure Notification Hubs iOS SDK](https://github.com/Azure/azure-notificationhubs-ios/releases) framework provided as a zip file and unzip it.
 
-- In Xcode, right-click your project and click the Add Files to option to add the WindowsAzureMessaging.framework folder to your Xcode project. Select Options and make sure Copy items if needed is selected, and then click Add.
+- In Xcode, right-click your project and click the **Add Files to** option to add the WindowsAzureMessaging.framework folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
 
 #### Start Notification Hubs SDK
 Previously, applications had to first manually request a device token (provided by the device manufacturer’s native push service) and then submit that token to Azure Notification Hubs. With the latest release, the Notification Hubs SDK automatically handles device registration for push notifications. When you add the SDK to your app, and enable push, the SDK automatically registers the device within the appropriate notification hub. Learn more about how to use the [Installations API](https://docs.microsoft.com/azure/notification-hubs/notification-hubs-push-notification-registration-management).
@@ -248,7 +248,7 @@ var tags = MSNotificationHub.getTags();
 
 #### Enable/disable push
 
-Just as the AppCenter Push SDK allowed to enable and disable Push, the Azure Notification Hubs SDK allows the user to enable and disable the SDK.
+Just as the AppCenter Push SDK allows you to enable and disable Push, the Azure Notification Hubs SDK allows you to enable and disable the SDK.
 
 **On Android**
 
@@ -273,7 +273,7 @@ The Notification Hubs SDK can also check if the SDK is enabled via the isEnabled
 
 **On iOS**
 
-To enable or disable the Azure Notification Hubs SDK, use the `setEnabled` method on the `MSNotificationHub`.  In addition, the user can also get the status of the SDK by called the `isEnabled` method.
+To enable or disable the Azure Notification Hubs SDK, use the `setEnabled` method on the `MSNotificationHub`.  In addition, the user can also get the status of the SDK by calling the `isEnabled` method.
 
 ##### In Objective-C
 
@@ -331,4 +331,4 @@ Check out our [tutorials](https://go.microsoft.com/fwlink/?linkid=2128396) to le
 Now that you've updated your app to use the new Notification Hubs SDK, and your back-end to push to Notification Hubs, you're all set to publish your new app.
 
 ## Support
-If you encounter issues with migrating your application to Azure Notification Hubs, please submit your feedback request for Android in the [Azure Notification Hubs SDK for Android](https://github.com/Azure/azure-notification-hubs-android/issues) repository, and for iOS in the [Azure Notification Hubs SDK for iOS](https://github.com/Azure/azure-notificationhubs-ios/issues).  
+If you encounter issues with migrating your application to Azure Notification Hubs, please submit your feedback request in the [Azure Notification Hubs repository](https://github.com/Azure/azureNotificationHubs/issues).  

--- a/docs/migration/push/index.md
+++ b/docs/migration/push/index.md
@@ -77,11 +77,32 @@ repositories {
 }
 ```
 
+**On iOS** 
+
+The Azure Notification Hubs SDK for iOS can be obtained a number of ways including CocoaPods, and direct download and integration.  Once the Azure Notification Hubs SDK release is final, it will be available via Carthage and the Swift Package Manager (SPM).
+
+#### Integration via CocoaPods
+
+Add the following dependencies to your podfile to include Azure Notification Hubs SDK into your app.
+
+```ruby
+pod 'AzureNotificationHubs-iOS'
+```
+
+#### Integration by copying binaries into your project
+
+- Download the [Azure Notification Hubs SDK](https://github.com/Azure/azure-notificationhubs-ios/releases) framework provided as a zip file and unzip it.
+
+- In Xcode, right-click your project and click the Add Files to option to add the WindowsAzureMessaging.framework folder to your Xcode project. Select Options and make sure Copy items if needed is selected, and then click Add.
+
 #### Start Notification Hubs SDK
 Previously, applications had to first manually request a device token (provided by the device manufacturer’s native push service) and then submit that token to Azure Notification Hubs. With the latest release, the Notification Hubs SDK automatically handles device registration for push notifications. When you add the SDK to your app, and enable push, the SDK automatically registers the device within the appropriate notification hub. Learn more about how to use the [Installations API](https://docs.microsoft.com/azure/notification-hubs/notification-hubs-push-notification-registration-management).
 
+**On Android** 
+
 Azure Notification Hubs SDK will be initialized with the application, default Listener Connection String from the Notification Hub, and the Notification Hub Name.
-```
+
+```java
 NotificationHub.initialize(
     this.getApplication()
     "{Hub Name}",
@@ -89,9 +110,43 @@ NotificationHub.initialize(
 );
 ```
 
-#### Intercept push notifications
-Set up a listener to be notified whenever a push notification is received in the background, or a foreground push notification is clicked by the user. Azure Notification Hubs registers a callback for notifications via the setListener method.
+**On iOS** 
+
+##### In Objective-C
+
+The Azure Notification Hubs, using Objective-C, can be initialized via the `MSNotificationHub` imported from the `WindowsAzureMessaging/WindowsAzureMessaging.h` header file, by calling the `initWithConnectionString` method.
+
+```objc
+#import <WindowsAzureMessaging/WindowsAzureMessaging.h>
+
+static NSString *const kConnectionString = @"{Connection String}";
+static NSString *const kHubName = @"{Hub Name}";
+
+[MSNotificationHub initWithConnectionString:kConnectionString hubName:kHubName];
 ```
+
+##### In Swift
+
+The Azure Notification Hubs SDK can be used by [importing Objective-C code into Swift](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_objective-c_into_swift) which creates the Objective-C bridging header.  Then, as before, the MSNotificationHub can be initialized as before.
+
+```swift
+import WindowsAzureMessaging
+
+static let connectionString = "{Connection String}"
+static let hubName = "{Hub Name}"
+
+MSNotificationHub.initWithConnectionString(connectionString, hubName: hubName)
+```
+
+#### Intercept push notifications
+
+Both on Android and iOS, the Azure Notification Hubs SDK registers your device with the platform specific remote notification system, such as Firebase on Android and APNS on iOS.  To allow for intercepting remote notifications, the uesr must set up a listener as shown in the following section.
+
+**On Android** 
+
+Set up a listener to be notified whenever a push notification is received in the background, or a foreground push notification is clicked by the user. Azure Notification Hubs registers a callback for notifications via the setListener method.
+
+```java
 NotificationHub.setListener(new NotificationListener() {
     @override 
     public void onNotificationReceived(Context context, NotificationMessage message) {
@@ -101,17 +156,56 @@ NotificationHub.setListener(new NotificationListener() {
 NotificationHub.initialize(this.getApplication(), "{Hub Name}", "{Connection String}"));
 ```
 This interface has a single method, which allows you to process the incoming custom NotificationMessage instance via the onNotificationReceived method. 
-```
+
+```java
 public interface NotificationListener {
     void onNotificationReceived(Context context, NotificationMessage message);
 }
 ```
 
+**On iOS**
+
+On iOS, you can intercept messages from APNS by implementing the `MSNotificationHubDelegate` protocol.
+
+##### In Objective-C
+
+```objc
+[MSNotificationHub setDelegate:self];
+[MSNotificationHub initWithConnectionString:kConnectionString hubName:kHubName];
+
+- (void)notificationHub:(MSNotificationHub *)notificationHub didReceivePushNotification:(MSNotificationHubMessage *)notification fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler  {
+    // Log the data
+    NSLog(@"Received notification: %@: %@", notification.title, notification.body);
+
+    // Set completion handler to no-data
+    completionHandler(UIBackgroundFetchResultNoData);
+}
+```
+
+##### In Swift
+
+```swift
+MSNotificationHub.setDelegate(self)
+MSNotificationHub.initWithConnectionString(connectionString!, hubName: hubName!)
+
+func notificationHub(_ notificationHub: MSNotificationHub!, didReceivePushNotification notification: MSNotificationHubMessage!, fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    // Log the data
+    NSLog("Received notification: %@; %@", notification.title ?? "<nil>", notification.body)
+
+    // Set completion handler to no-data
+    completionHandler(.noData)
+}
+```
+
 #### Target devices
+
 The new Notification Hubs SDK supports tags that allow you to collect custom properties, associate them with users & devices, and use them for targeting an audience.
 
+**On Android**
+
 The NotificationHub class has information about tags and how to add, remove, clear, and list the tags. It can also add or remove tags via a List<String> with addTags and removeTags. Below is a sample of adding, removing, and fetching all tags. 
-```
+
+```java
 // Add a tag
 NotificationHub.addTag("android");
 
@@ -122,21 +216,89 @@ NotificationHub.removeTag("android");
 Iterable<String> tags = NotificationHub.getTags();
 ```
 
-#### Enable/disable push
-To enable or disable the SDK, use the setEnabled method, passing false to disable the SDK and true to enable it. Both APIs are asynchronous using the NotificationHubFuture class. 
+**On iOS**
+
+The `MSNotificationHub` class has information about tags to add, remove and list the tags.  These methods can also accept an `NSArray` of strings for tags.  Below is a sample of adding, removing, and fetching all tags for both Objective-C and Swift.
+
+##### In Objective-C
+
+```objc
+// Add a tag
+[MSNotificationHub addTag:@"iOS"];
+
+// Remove a tag
+[MSNotificationHub removeTag:@"iOS"];
+
+// Get tags
+NSArray *tags = [MSNotificationHub getTags];
 ```
+
+##### In Swift
+
+```swift
+// Add a tag
+MSNotificationHub.addTag("iOS")
+
+// Remove a tag
+MSNotificationHub.removeTag("iOS");
+
+// Get tags
+var tags = MSNotificationHub.getTags();
+```
+
+#### Enable/disable push
+
+Just as the AppCenter Push SDK allowed to enable and disable Push, the Azure Notification Hubs SDK allows the user to enable and disable the SDK.
+
+**On Android**
+
+To enable or disable the SDK, use the setEnabled method, passing false to disable the SDK and true to enable it. Both APIs are asynchronous using the NotificationHubFuture class. 
+
+```java
 // Disable the SDK
 NotificationHub.setEnabled(false)
 
 // Enable the SDK
 NotificationHub.setEnabled(true)
 ```
+
 The Notification Hubs SDK can also check if the SDK is enabled via the isEnabled async method. 
-```
+
+```java
 /**
   * Gets whether the SDK is enabled. Will always return false before initialize is called
 */
     public NotificationHubFuture<boolean>boolean isEnabled();
+```
+
+**On iOS**
+
+To enable or disable the Azure Notification Hubs SDK, use the `setEnabled` method on the `MSNotificationHub`.  In addition, the user can also get the status of the SDK by called the `isEnabled` method.
+
+##### In Objective-C
+
+```objc
+// Disable the SDK
+[MSNotificationHub setEnabled:NO];
+
+// Enable the SDK
+[MSNotificationHub setEnabled:YES];
+
+// Check the status
+BOOL enabled = [MSNotificationHub isEnabled];
+```
+
+##### In Swift
+
+```swift
+// Disable the SDK
+MSNotificationHub.setEnabled(false);
+
+// Enable the SDK
+MSNotificationHub.setEnabled(true);
+
+// Check the status
+var enabled = MSNotificationHub.isEnabled();
 ```
 
 ### Send notifications using Azure Notification Hubs 
@@ -169,4 +331,4 @@ Check out our [tutorials](https://go.microsoft.com/fwlink/?linkid=2128396) to le
 Now that you've updated your app to use the new Notification Hubs SDK, and your back-end to push to Notification Hubs, you're all set to publish your new app.
 
 ## Support
-If you encounter issues with migrating your application to Azure Notification Hubs, please submit your feedback request in the [ANH GitHub repository](https://github.com/Azure/AzureNotificationHubs/issues).  
+If you encounter issues with migrating your application to Azure Notification Hubs, please submit your feedback request for Android in the [Azure Notification Hubs SDK for Android](https://github.com/Azure/azure-notification-hubs-android/issues) repository, and for iOS in the [Azure Notification Hubs SDK for iOS](https://github.com/Azure/azure-notificationhubs-ios/issues).  


### PR DESCRIPTION
This PR updates the iOS part of the AppCenter Push to Azure Notification Hubs SDK migration.  Note, I am part of the Azure Notification Hubs team.