### PR TITLE
Update React Native Build documentation to mention Expo CLI

### DIFF
--- a/docs/build/react-native/index.md
+++ b/docs/build/react-native/index.md
@@ -19,4 +19,6 @@ You can build React Native apps for both Android and iOS. To get started, use th
 - [Configuring your first Android build](~/build/react-native/android/index.md)
 - [Configuring your first iOS build](~/build/react-native/ios/index.md)
 
+Currently React Native Build does not contain support for Expo.
+
 We're constantly adding features and more capabilities. If you need further support in building your app, [contact us](https://intercom.help/appcenter/) and let us know more about your needs.


### PR DESCRIPTION
If you navigate to the React Native Documentation on setting up your environment, you will notice that the first thing you see is setting up React Native with Expo. Because of the prevalence of Expo within React Native and issues like this (https://github.com/microsoft/appcenter/issues/224) it might be nice to include the lack of support for expo when using React Native Build