### PR TITLE
docs: add token being broken if team member leaves org

### DIFF
--- a/docs/api-docs/index.md
+++ b/docs/api-docs/index.md
@@ -132,6 +132,8 @@ This section shows you how to use App Center's [OpenAPI page](https://openapi.ap
 ## Revoking an API Token
 In the event that an API token is leaked, you should revoke it immediately to prevent unauthorized access to your App Center account.
 
+Additionally, in the event of a member of your organization having its corporate e-mail deactivated. The token will automatically be unrecognizable. That would only happen if the member was the one who created that token. You should create a new one.
+
 ### Revoking a User API token
 1. Navigate to [https://appcenter.ms](https://appcenter.ms).
 2. On the top-right corner of the App Center portal, click your account avatar, then select **Account Settings**.

--- a/docs/distribution/uploading.md
+++ b/docs/distribution/uploading.md
@@ -126,3 +126,11 @@ You can find links to specific releases to public destinations on the releases t
 [app-center-home]: https://appcenter.ms/apps
 [apple-register-single-device]: https://help.apple.com/developer-account/#/dev40df0d9fa
 [apple-register-multiple-devices]: https://help.apple.com/developer-account/#/devebd34abb1
+
+## Troubleshooting
+
+### I'm getting "404: Not Found" when I try to upload my binaries to AppCenter distribution
+
+This error can happen if a member of your company got its corporate e-mail deactivated. Not having the member inside of the AppCenter's org, but also if the member was the one who created the API tokens to publish to AppCenter, it might end-up with the token getting rejected.
+
+To avoid that to happen, make sure you create the API tokens inside of the apps settings that you are going to distribute. In that sense, the token creation will be bound to the app and not to the user.


### PR DESCRIPTION
Add a section that helps with troubleshooting in the event of a team member leaving the company and having its e-mail deactivated. That may cause AppCenter not recognizing the token anymore if the member was the one that created it.