### PR TITLE
docs(custom-scripts): CFBundleName -> CFBundleDisplayName

### DIFF
--- a/docs/build/custom/scripts/index.md
+++ b/docs/build/custom/scripts/index.md
@@ -59,7 +59,7 @@ To run scripts pre-build, add the following file next to the project file in you
     # Example: Change bundle name of an iOS app for non-production
     if [ "$APPCENTER_BRANCH" != "master" ];
     then
-        plutil -replace CFBundleName -string "\$(PRODUCT_NAME) Beta" $APPCENTER_SOURCE_DIRECTORY/MyApp/Info.plist
+        plutil -replace CFBundleDisplayName -string "\$(PRODUCT_NAME) Beta" $APPCENTER_SOURCE_DIRECTORY/MyApp/Info.plist
     fi
     ```
 


### PR DESCRIPTION
CFBundleDisplayName is the property that is responsible for the app name on the device.