### PR TITLE
Command Update: CodePush Android Note Instructions

### DIFF
--- a/docs/distribution/codepush/rn-deployment.md
+++ b/docs/distribution/codepush/rn-deployment.md
@@ -40,7 +40,7 @@ You will notice that the above steps refer to a "staging build" and "production 
 The [Android Gradle plugin](https://google.github.io/android-gradle-dsl/current/index.html) allows you to define custom config settings for each "build type" (like debug, release). This mechanism allows you to easily configure your debug builds to use your CodePush staging deployment key and your release builds to use your CodePush production deployment key.
 
 > [!NOTE]
-> As a reminder, you can retrieve these keys by running `appcenter codepush deployment list <ownerName>/<appName> -k` from your terminal.*
+> As a reminder, you can retrieve these keys by running `appcenter codepush deployment list -a <ownerName>/<appName> -k` from your terminal.*
 
 To set this up, perform the following steps:
 


### PR DESCRIPTION
### Problem

The current command is listed as below in the Note section of https://docs.microsoft.com/en-ca/appcenter/distribution/codepush/rn-deployment#android

`appcenter codepush deployment list <ownerName>/<appName> -k` 

The current command causes to failed due to "Unknown arguments: <ownerName>/<appName>"

### Proposed Solution

The proposed solution is to add the application flag to the command as 

`appcenter codepush deployment list -a <ownerName>/<appName> -k`