### PR TITLE
Add link to NetSparkleUpdater as option for Win

### DIFF
--- a/docs/distribution/sparkleupdates.md
+++ b/docs/distribution/sparkleupdates.md
@@ -13,7 +13,7 @@ ms.assetid: b5c07e60-985b-4941-a139-a203ea912d5a
 
 # Sparkle Updates
 
-Sparkle is a software update framework for [macOS](http://sparkle-project.org) and [Windows](https://winsparkle.org/) apps.
+Sparkle is a software update framework for [macOS](http://sparkle-project.org) and Windows ([WinSparkle](https://winsparkle.org), [NetSparkleUpdater](https://github.com/NetSparkleUpdater/NetSparkle)) apps.
 
 ## Setup for distribution
 


### PR DESCRIPTION
Disclaimer: I am the author/maintainer of NetSparkleUpdater, a Sparkle-style Windows software update framework written in C#. Before suggesting this change, I asked permission of the WinSparkle library (https://github.com/vslavik/winsparkle/issues/213) to make this change, and we agreed on the verbiage to use.

This PR simply adds a link to `NetSparkleUpdater` along with the existing link to `WinSparkle`.