### PR TITLE
Update your-data: export cancellation endpoint

### DIFF
--- a/docs/gdpr/your-data.md
+++ b/docs/gdpr/your-data.md
@@ -88,7 +88,7 @@ Some of App Center's services may take a while to execute an export. For long ru
 To cancel your export request, use the cancellation endpoint:
 
 ```TEXT
-https://appcenter.ms/api/v0.1/user/dsr/delete/<your receipt token>/cancel
+https://appcenter.ms/api/v0.1/user/dsr/export/<your receipt token>/cancel
 ```
 
 A raw request in Postman or Fiddler to make a cancellation request will look like this:


### PR DESCRIPTION
The export cancellation endpoint contains a URL pointing to the delete endpoint. I suspect this should be the export endpoint instead, as the raw Postman/Fiddler example does point out the export endpoint.