### PR TITLE
Document android signing change (using 

### DIFF
--- a/docs/build/android/code-signing.md
+++ b/docs/build/android/code-signing.md
@@ -35,6 +35,11 @@ App Center supports three different ways of setting up code signing for Android 
 
 Then, depending on your scenario, use the most suitable of the three options in the sections below. The first option involves checking in credentials to your repository, while the other two use App Center to handle your credentials instead.
 
+As of Android 11 it's mandatory to use the APK signer (If you use the 30 SDK), as it will set some extra schemes "APK Signature Scheme v2 now required". App Center now (as of Dec 17, 2020) signs Android applications using APK signer internally, instead of JAR signer which was used previously. As part of the feature to enable APK signer in App Center, Android signing task V3 was implemented, and requirements for new Signing task were to change how keystore file was saved - storing the keystore file in an AzDO secure file ([Android signing build and release task - Azure Pipelines | Microsoft Docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/android-signing?view=azure-devops#arguments)).
+
+> [!WARNING]
+> Any build configurations that had their keystore files uploaded prior to Dec 17, 2020. still use the old signing method (jarsigner). To use the new signing flow, users just have to **re-upload their keystore files**, and **save** their branch configuration.
+
 > [!NOTE]
 > Usage of Android Gradle Plugin version 4.1.x is not fully supported. In order to use this version, you must add the next option setting in the  `gradle.properties` file:
 >

--- a/docs/build/android/code-signing.md
+++ b/docs/build/android/code-signing.md
@@ -4,7 +4,7 @@ description: How to set up code signing for Android apps
 keywords: android
 author: lucen-ms
 ms.author: lucen
-ms.date: 12/10/2019
+ms.date: 13/10/2021
 ms.topic: article
 ms.assetid: 656b4c96-d2b8-456a-9cd8-b7cbc827cdf0
 ms.service: vs-appcenter


### PR DESCRIPTION
Update to documentation regarding switching to using Android signing with apksigner(pipeline task Android signing V3.)

App Center feature link: https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/83446