### PR TITLE
Note: do not ignore Gradle wrapper files

### DIFF
--- a/docs/build/android/index.md
+++ b/docs/build/android/index.md
@@ -23,6 +23,9 @@ To build your first Android app, follow these steps:
 > [!NOTE]
 > For the app to run on a real device, the build needs to be code signed with a valid certificate.
 
+> [!NOTE]
+> App Center tracks the project by searching the gradle(and gradlew) directory files on the Android project, please do not ignore those files(on the project .gitignore) as App Center Build service will not find it.
+
 > [!WARNING]
 > Due to the recent shutdown of JCenter, certain apps may experience Gradle Task failures when building with App Center. Please view the migration guide provided by Gradle. As a workaround, all instances of `jcenter()` can be removed from the `build.gradle` file, and replaced with `jcenter { url "http://jcenter.bintray.com/"}`. Read more about the JCenter Shutdown [here](~/build/android/jcentershut.md).
 

--- a/docs/build/android/index.md
+++ b/docs/build/android/index.md
@@ -24,7 +24,7 @@ To build your first Android app, follow these steps:
 > For the app to run on a real device, the build needs to be code signed with a valid certificate.
 
 > [!NOTE]
-> App Center tracks the project by searching the gradle(and gradlew) directory files on the Android project, please do not ignore those files(on the project .gitignore) as App Center Build service will not find it.
+> The App Center tracks the project by searching the gradle (and gradlew) directory files of the Android project. Please do not include these files in the project .gitignore as App Center Build will not be able to find them.
 
 > [!WARNING]
 > Due to the recent shutdown of JCenter, certain apps may experience Gradle Task failures when building with App Center. Please view the migration guide provided by Gradle. As a workaround, all instances of `jcenter()` can be removed from the `build.gradle` file, and replaced with `jcenter { url "http://jcenter.bintray.com/"}`. Read more about the JCenter Shutdown [here](~/build/android/jcentershut.md).


### PR DESCRIPTION
App Center Build Service does not find the project when you ignore the Gradle wrapper files, add a quick notice to not ignore those files on the docs, example:
ignore these files:
![image](https://user-images.githubusercontent.com/87332696/151454285-7b973459-393b-4058-981f-bb79e7d330e5.png)
will show this on App Center Build:
![image](https://user-images.githubusercontent.com/87332696/151454772-66e9d23c-65ae-4d0e-ac03-dc950741f3e7.png)
if those files are ignored App Center Build might not find them, as some IDE generates them, like Android Studio the users may ignore them, for example Android Flutter projects (which aren't  yet supported officially, see: microsoft/appcenter#67  )  ignore it by default, this PR adds a quick note that warns the user to not ignore them.

Quick Notes:
- this is also discussed on the [Flutter GitHub](https://github.com/flutter/flutter/issues/30858) as many users ignore them.
- this issue is not specific to flutter many users may ignore it without knowledge of this.
- it should be a note about this also on the sample flutter script microsoft/appcenter#2375