### PR TITLE
Add the rollbackRetryOptions definitions

### DIFF
--- a/docs/distribution/codepush/rn-api-ref.md
+++ b/docs/distribution/codepush/rn-api-ref.md
@@ -157,6 +157,14 @@ The `codePush` decorator accepts an "options" object that allows you to customiz
 
   - **title** *(String)* - The text used as the header of an update notification that's displayed to the end user. Defaults to `"Update available"`.
 
+- **rollbackRetryOptions** *(RollbackRetryOptions)* - The rollback retry mechanism allows the application to attempt to reinstall an update that was previously rolled back (with the restrictions specified in the options). It is an "options" object used to determine whether a rollback retry should occur, and if so, what settings to use for the rollback retry. This defaults to null, which has the effect of disabling the retry mechanism. Setting this to any truthy value will enable the retry mechanism with the default settings, and passing an object to this parameter allows enabling the rollback retry as well as overriding one or more of the default values.
+
+    The following list represents the available options and their defaults:
+
+  - **delayInHours** *(Number)* - Specifies the minimum time in hours that the app will wait after the latest rollback before attempting to reinstall the same rolled-back package. Defaults to `24`.
+
+  - **maxRetryAttempts** *(Number)* - Specifies the maximum number of retry attempts that the app can make before it stops trying. Cannot be less than `1`. Defaults to `1`.
+
 #### codePushStatusDidChange (event hook)
 
 Called when the sync process moves from one stage to another in the overall update process. The event hook is called with a status code that represents the current state, and can be any of the [`SyncStatus`](#syncstatus) values.
@@ -424,6 +432,8 @@ While the `sync` method tries to make it easy to do silent and active updates wi
 
 - **updateDialog** *(UpdateDialogOptions)* - Refer to [`CodePushOptions`](#codepushoptions).
 
+- **rollbackRetryOptions** *(RollbackRetryOptions)* - Refer to [`CodePushOptions`](#codepushoptions).
+
 Example Usage:
 
 ```javascript
@@ -453,6 +463,16 @@ codePush.sync({
     descriptionPrefix: "\n\nChange log:\n"
    },
    installMode: codePush.InstallMode.IMMEDIATE
+});
+
+// Shortening the retry delay and increasing
+// the number of maximum retry attempts
+// in comparison to defaults
+codePush.sync({
+   rollbackRetryOptions: {
+    delayInHours: 8,
+    maxRetryAttempts: 3
+   }
 });
 ```
 


### PR DESCRIPTION
In the CodePush repo docs we have mentioned that rollbackRetryOptions property is available.
Actually, it is available for almost 3 years now, from v. 5.5.0, while now it.s v. 7.0.0+.

https://github.com/Microsoft/react-native-code-push/blob/master/docs/api-js.md#codepushoptions

This PR adds definitions and examples for it in Microsoft Docs to avoid any misunderstandings.