### PR TITLE
Maximum apps created or configured per day

### DIFF
--- a/docs/general/platform-limits.md
+++ b/docs/general/platform-limits.md
@@ -28,3 +28,4 @@ The following limits are in effect for App Center usage.
 - Maximum number of API tokens per account: 10,000 API tokens
 - Maximum number of API tokens for each organization: 10,000 API tokens
 - Maximum number of members for each app release: 2,000 members
+- Maximum number of apps created or configured per day: 5 apps


### PR DESCRIPTION
Appstore connect updated number of apps that can be created/configured a day from 30 to 5 to reduce and prevent potential abuse.