### PR TITLE
Correct option name for releasing signed updates

### DIFF
--- a/docs/distribution/codepush/cli.md
+++ b/docs/distribution/codepush/cli.md
@@ -867,4 +867,4 @@ puayMcrx2unhKQyDYjUvD8GxHyquA+p52KDke2TkKfDxfzv0WOE1
 
 ### Releasing signed update
 
-To release signed update, you should use `--privateKeyPath` (or `-k`) option for `release` or `release-react` command.
+To release a signed update, you should use the `--private-key-path` (or `-k`) option for the `release` or `release-react` command.


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/appcenter-docs/issues/1334

In [the docs for `appcenter-cli`](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/cli#installation) when setting up code signing [you are instructed to pass the private key path using the `--privateKeyPath` flag](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/cli#code-signing). When you use that flag the command fails and prints out an error message: `Unknown argument --privateKeyPath`.

This PR corrects the docs to list the correct `--private-key-path` option instead.