### PR TITLE
added missing available Node.js versions

### DIFF
--- a/docs/build/react-native/nodejs.md
+++ b/docs/build/react-native/nodejs.md
@@ -15,7 +15,6 @@ ms.tgt_pltfrm: react-native
 # Node.js selection
 
 ## Major versions of Node.js
-Any major Node.js version can be specified in the app's branch configuration.
 The following versions are available for use in App Center Build: 6.X, 8.x, 10.x, 12.x, 14.x, 16.X.
 See Also: [App Center Cloud Build Machines](~/build/software.md)
 

--- a/docs/build/react-native/nodejs.md
+++ b/docs/build/react-native/nodejs.md
@@ -15,8 +15,8 @@ ms.tgt_pltfrm: react-native
 # Node.js selection
 
 ## Major versions of Node.js
-Any major Node.js version can be specified in the app's branch configuration.  
-The following versions are available for use in App Center Build: 8.x, 10.x, 12.x, 14.x. 
+Any major Node.js version can be specified in the app's branch configuration.
+The following versions are available for use in App Center Build: 6.X, 8.x, 10.x, 12.x, 14.x, 16.X.
 See Also: [App Center Cloud Build Machines](~/build/software.md)
 
 ![Select Node.js version in the app's branch configuration](~/build/react-native/images/node-select.png)


### PR DESCRIPTION
6.X is still available, so it should be on the list.
16.X is available, not sure how long it has been available but the documentation didnt include it.