### PR TITLE
correct some parameters used by distributing a release via calling API

### DIFF
--- a/docs/distribution/uploading.md
+++ b/docs/distribution/uploading.md
@@ -1,4 +1,4 @@
----
+
 title: Distribute a build via App Center
 description: Distribute a completed build to users
 keywords: distribution
@@ -143,7 +143,7 @@ Upload a new release using these sequential API calls:
    ```json
     {
         "error":false,
-        "id":"{UPLOAD_ID}",
+        "id":"{PACKAGE_ASSET_ID}",
         "chunk_size":4194304,
         "resume_restart":false,
         "chunk_list":[1,2,3,4,5],
@@ -179,9 +179,9 @@ Upload a new release using these sequential API calls:
     FINISHED_URL="https://file.appcenter.ms/upload/finished/$PACKAGE_ASSET_ID?token=$URL_ENCODED_TOKEN"
     curl -d POST -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" "$FINISHED_URL"
         
-    COMMIT_URL="https://api.appcenter.ms/v0.1/apps/$OWNER_NAME/$APP_NAME/uploads/releases/$UPLOAD_ID"
+    COMMIT_URL="https://api.appcenter.ms/v0.1/apps/$OWNER_NAME/$APP_NAME/uploads/releases/$ID"
     curl -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" \
-    --data '{"upload_status": "uploadFinished","id": "$UPLOAD_ID"}' \
+    --data '{"upload_status": "uploadFinished","id": "$ID"}' \
     -X PATCH \
     $COMMIT_URL
     ```


### PR DESCRIPTION
I found there is something wrong with the sample of distributing a release via calling API, which confused our customers on Intercom.

1. At step two,
_{
     "error":false,
     **"id":"{UPLOAD_ID}",**
     "chunk_size":4194304,
     "resume_restart":false,
     "chunk_list":[1,2,3,4,5],
     "blob_partitions":1,
     "status_code":"Success"
 }_

The "id" parameter should be the package asset id, which is returned at step one.  The actual upload id should be the below.

2. At step five.

_COMMIT_URL="https://api.appcenter.ms/v0.1/apps/$OWNER_NAME/$APP_NAME/uploads/releases/$UPLOAD_ID"
curl -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" \
--data '{"upload_status": "uploadFinished","id": "**$UPLOAD_ID**"}' \
-X PATCH \
$COMMIT_URL_

The actual UPLOAD_ID should be the ID parameter, which is returned at step one.

_{
         **"id": "{ID}",**
         "package_asset_id": "{PACKAGE_ASSET_ID}",
         "upload_domain": "https://file.appcenter.ms",
         "token": "{TOKEN}",
         "url_encoded_token": "{URL_ENCODED_TOKEN}"
     }_
    
Intercom case.
https://app.intercom.com/a/apps/r33tq287/inbox/inbox/conversation/53577900979383
     