### PR TITLE
Fixed link to App Store Connect

### DIFF
--- a/docs/distribution/stores/apple.md
+++ b/docs/distribution/stores/apple.md
@@ -19,7 +19,7 @@ Publish iOS app upgrades to the App Store and TestFlight with Fastlane in App Ce
 * The first version of an iOS application must be published through the App Store Connect portal.
 * Compile the app using an App Store provisioning profile and production certificate.
 * App should be ready for submission and pass the [App Store guidelines](https://developer.apple.com/app-store/review/guidelines/).
-* An active [Apple Developer Program](https://developer.apple.com/programs/enroll/) account, or have your Apple ID added as an admin in your teams' [App Store Connect](https://itunesconnect.apple.com/login) account.
+* An active [Apple Developer Program](https://developer.apple.com/programs/enroll/) account, or have your Apple ID added as an admin in your teams' [App Store Connect](https://appstoreconnect.apple.com/) account.
 * The connected account must have App Manager permissions to publish an app.
 
 For more information, review the [Apple App Distribution Guide](https://help.apple.com/xcode/mac/current/#/dev8b4250b57).


### PR DESCRIPTION
Fixed link to App Store Connect - replaced old itunesconnect.apple.com link