### PR TITLE
Fix incorrect 'curl -d POST' calls

### DIFF
--- a/docs/distribution/uploading.md
+++ b/docs/distribution/uploading.md
@@ -136,7 +136,7 @@ Upload a new release using these sequential API calls:
     
     METADATA_URL="https://file.appcenter.ms/upload/set_metadata/$PACKAGE_ASSET_ID?file_name=$FILE_NAME&file_size=$FILE_SIZE_BYTES&token=$URL_ENCODED_TOKEN&content_type=$APP_TYPE"
 
-     curl -s -d POST -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" "$METADATA_URL"
+     curl -s -X POST -H "Content-Length: 0" -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" "$METADATA_URL"
      ```
     
    The output returned should look something like this:
@@ -177,7 +177,7 @@ Upload a new release using these sequential API calls:
 5. After the upload is done, update the upload resource's status to `uploadFinished`.
     ```sh
     FINISHED_URL="https://file.appcenter.ms/upload/finished/$PACKAGE_ASSET_ID?token=$URL_ENCODED_TOKEN"
-    curl -d POST -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" "$FINISHED_URL"
+    curl -X POST -H "Content-Length: 0" -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" "$FINISHED_URL"
         
     COMMIT_URL="https://api.appcenter.ms/v0.1/apps/$OWNER_NAME/$APP_NAME/uploads/releases/$ID"
     curl -H "Content-Type: application/json" -H "Accept: application/json" -H "X-API-Token: $API_TOKEN" \


### PR DESCRIPTION
'curl -d POST' actually posts to the url with a four byte request body 'POST', while those urls should actually be posted to without a request body. 'curl -X POST' does this. Also adding '-H "Content-Length: 0" as required by the server